### PR TITLE
word2vec api change, vector->word

### DIFF
--- a/p5js/Word2Vec/sketch.js
+++ b/p5js/Word2Vec/sketch.js
@@ -43,7 +43,7 @@ function setup() {
     let word1 = betweenWordInput1.value();
     let word2 = betweenWordInput2.value();
     let average = word2Vec.average([word1, word2], 1);
-    betweenResults.html(average[0].vector);
+    betweenResults.html(average[0].word);
   });
 
   // Adding two words together to "solve" an analogy
@@ -52,8 +52,8 @@ function setup() {
     let to1 = addInput2.value();
     let is2 = addInput3.value();
     let difference = word2Vec.subtract([to1, is1]);
-    let to2 = word2Vec.add([is2, difference[0].vector]);
-    addResults.html(to2[0].vector);
+    let to2 = word2Vec.add([is2, difference[0].word]);
+    addResults.html(to2[0].word);
   });
 }
 
@@ -71,7 +71,7 @@ function findNearest(word, n = 10) {
     }
     let output = '';
     for (let i = 0; i < nearest.length; i++) {
-      output += nearest[i].vector + '<br/>';
+      output += nearest[i].word + '<br/>';
     }
     return output;
   }


### PR DESCRIPTION
This changes the `vector` property in the results returned to `word` addressing https://github.com/ml5js/ml5-library/issues/153

This should not be merged until this is complete and the library is re-built:
https://github.com/ml5js/ml5-library/pull/160