### PR TITLE
Required to work on Firefox

### DIFF
--- a/p5js/PoseNet/index.html
+++ b/p5js/PoseNet/index.html
@@ -13,6 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.sound.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.1/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>


### PR DESCRIPTION
Otherwise getting "uncaught exception: getUserMedia not supported in this browser" as 
https://github.com/processing/p5.js-sound/blob/master/src/audioin.js 

If that's indeed the reason then it might be interesting to bring the related getUserMedia helper/polyfill up to p5js or p5js dom.