### PR TITLE
SketchRNN examples

### DIFF
--- a/p5js/SketchRNN/SketchRNN_basic/index.html
+++ b/p5js/SketchRNN/SketchRNN_basic/index.html
@@ -12,13 +12,14 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
-    <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+    <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+    <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   </head>
 
   <body>
     <h1>SketchRNN</h1>
     <p id="status">Loading Model...</p>
-    <p><button id="draw">Draw</button></p>
+    <p><button id="clear">clear</button></p>
     <script src="sketch.js"></script>
   </body>
 </html>

--- a/p5js/SketchRNN/SketchRNN_basic/sketch.js
+++ b/p5js/SketchRNN/SketchRNN_basic/sketch.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2018 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/* ===
+ml5 Example
+SketchRNN
+=== */
+
+// The SketchRNN model
+let model;
+// Start by drawing
+let previous_pen = 'down';
+// Current location of drawing
+let x, y;
+// The current "stroke" of the drawing
+let strokePath;
+
+function setup() {
+  createCanvas(640, 480);
+  background(220);
+  // Load the model
+  // See a list of all supported models: https://github.com/ml5js/ml5-library/blob/master/src/SketchRNN/models.js
+  model = ml5.SketchRNN('cat', modelReady);
+
+  // Button to start drawing
+  let button = select('#clear');
+  button.mousePressed(startDrawing);
+}
+
+// Reset the drawing
+function startDrawing() {
+  background(220);
+  // Start in the middle
+  x = width / 2;
+  y = height / 2;
+  model.reset();
+  // Generate the first stroke path
+  model.generate(gotStroke);
+}
+
+function draw() {
+  // If something new to draw
+  if (strokePath) {
+    // If the pen is down, draw a line
+    if (previous_pen == 'down') {
+      stroke(0);
+      strokeWeight(3.0);
+      line(x, y, x + strokePath.dx, y + strokePath.dy);
+    }
+    // Move the pen
+    x += strokePath.dx;
+    y += strokePath.dy;
+    // The pen state actually refers to the next stroke
+    previous_pen = strokePath.pen;
+
+    // If the drawing is complete
+    if (strokePath.pen !== 'end') {
+      strokePath = null;
+      model.generate(gotStroke);
+    }
+  }
+}
+
+// A new stroke path
+function gotStroke(err, s) {
+  strokePath = s;
+}
+
+// The model is ready
+function modelReady() {
+  select('#status').html('model ready');
+  startDrawing();
+}

--- a/p5js/SketchRNN/SketchRNN_interactive/index.html
+++ b/p5js/SketchRNN/SketchRNN_interactive/index.html
@@ -1,0 +1,25 @@
+<!--
+  Copyright (c) 2018 ml5
+
+  This software is released under the MIT License.
+  https://opensource.org/licenses/MIT
+-->
+
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>SketchRNN</title>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+    <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+    <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
+  </head>
+
+  <body>
+    <h1>SketchRNN</h1>
+    <p id="status">Loading Model...</p>
+    <p><button id="clear">Clear</button></p>
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/p5js/SketchRNN/index.html
+++ b/p5js/SketchRNN/index.html
@@ -1,27 +1,24 @@
 <!--
- Copyright (c) 2018 ml5
- 
- This software is released under the MIT License.
- https://opensource.org/licenses/MIT
+  Copyright (c) 2018 ml5
+
+  This software is released under the MIT License.
+  https://opensource.org/licenses/MIT
 -->
 
 <html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>SketchRNN</title>
 
-<head>
-  <meta charset="UTF-8">
-  <title>SketchRNN</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+    <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  </head>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
-
-</head>
-
-<body>
-  <h1>SketchRNN</h1>
-  <p id="status">Loading Model...</p>
-  <button id="draw">Draw</button>
-  <script src="sketch.js"></script>
-</body>
-
+  <body>
+    <h1>SketchRNN</h1>
+    <p id="status">Loading Model...</p>
+    <p><button id="draw">Draw</button></p>
+    <script src="sketch.js"></script>
+  </body>
 </html>

--- a/p5js/SketchRNN/sketch.js
+++ b/p5js/SketchRNN/sketch.js
@@ -8,50 +8,68 @@ ml5 Example
 SketchRNN
 === */
 
+// The SketchRNN model
 let model;
+// Start by drawing
 let previous_pen = 'down';
+// Current location of drawing
 let x, y;
-let sketch;
+// The current "stroke" of the drawing
+let strokePath;
 
 function setup() {
-  createCanvas(400, 300);
+  createCanvas(640, 480);
+  background(220);
+  // Load the model
+  // See a list of all supported models: https://github.com/ml5js/ml5-library/blob/master/src/SketchRNN/models.js
   model = ml5.SketchRNN('cat', modelReady);
+
+  // Button to start drawing
   let button = select('#draw');
   button.mousePressed(startDrawing);
 }
 
+// Reset the drawing
 function startDrawing() {
+  background(220);
+  // Start in the middle
   x = width / 2;
   y = height / 2;
-  background(220);
   model.reset();
-  model.generate(gotSketch);
+  // Generate the first stroke path
+  model.generate(gotStroke);
 }
 
 function draw() {
-  if (sketch) {
+  // If something new to draw
+  if (strokePath) {
+    // If the pen is down, draw a line
     if (previous_pen == 'down') {
       stroke(0);
       strokeWeight(3.0);
-      line(x, y, x + sketch.dx, y + sketch.dy);
+      line(x, y, x + strokePath.dx, y + strokePath.dy);
     }
-    x += sketch.dx;
-    y += sketch.dy;
-    previous_pen = sketch.pen;
+    // Move the pen
+    x += strokePath.dx;
+    y += strokePath.dy;
+    // The pen state actually refers to the next stroke
+    previous_pen = strokePath.pen;
 
-    if (sketch.pen !== 'end') {
-      sketch = null;
-      model.generate(gotSketch);
+    // If the drawing is complete
+    if (strokePath.pen !== 'end') {
+      strokePath = null;
+      model.generate(gotStroke);
     }
-  } 
+  }
 }
 
-function gotSketch(err, s) {
-  sketch = s;
+// A new stroke path
+function gotStroke(err, s) {
+  strokePath = s;
 }
 
+// The model is ready
 function modelReady() {
-  select('#status').html('Model Loaded');
+  select('#status').html('model ready');
   startDrawing();
 }
-


### PR DESCRIPTION
Here are two new SketchRNN examples! The first just draws a generated sketch. The second draws based on a user's initial stroke. I could make a third example (or adapt the second) to pause SketchRNN while drawing if a user takes over. @hardmaru would love for you to take a look!

Also, the second example will only work with a version of the library that includes this https://github.com/ml5js/ml5-library/pull/237. @cvalenzuela could we do a quick 0.1.3 with this fix? I might like to do a video tutorial about SketchRNN tomorrow. But I can also hold off and/or use a pre-built version of the library in the tutorial.