### PR TITLE
Add 2 KNN Classifier examples

### DIFF
--- a/p5js/KNNClassification/KNNClassification_Video/index.html
+++ b/p5js/KNNClassification/KNNClassification_Video/index.html
@@ -13,8 +13,7 @@
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
-  <!-- <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script> -->
-  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.1/dist/ml5.min.js" type="text/javascript"></script>
   
   <style>
   button {

--- a/p5js/KNNClassification/KNNClassification_VideoSound/index.html
+++ b/p5js/KNNClassification/KNNClassification_VideoSound/index.html
@@ -1,20 +1,21 @@
 <!--
-  Copyright (c) 2018 ml5
-  
-  This software is released under the MIT License.
-  https://opensource.org/licenses/MIT
+ Copyright (c) 2018 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
 -->
 
 <html>
 
 <head>
   <meta charset="UTF-8">
-  <title>PoseNet with KNN Classification on Webcam Images. Built with p5.js</title>
+  <title>KNN Classification on Webcam Images with Speech Output Using mobileNet. Built with p5.js</title>
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
+  <script src="lib/p5.speech.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.2.1/dist/ml5.min.js" type="text/javascript"></script>
-
+  
   <style>
   button {
     margin: 6px 6px 6px 0;
@@ -29,26 +30,19 @@
     display: inline;
     font-size: 16px;
   }
-  .emoji {
-    font-size: 24px;
-  }
   </style>
 </head>
 
 <body>
-  <h2>KNN Classification on PoseNet data from webcam. Built with p5.js</h2>
+  <h2>KNN Classification on Webcam Images with Speech Output Using mobileNet. Built with p5.js</h2>
   <div id="videoContainer"></div>
   <p id="status">Loading Model...</p>
   <br><p>
-    <button id="addClassA">Add an Example to Class A</button>
-    <button id="resetA">Reset Class A</button>
-    <p><span id="exampleA">0</span> A examples</p>
-    <p>| Confidence in A is: <span id="confidenceA">0</span></p>
+    <button id="addClass1">Add an Example to Class "Hello"</button>
+    <p><span id="example1">0</span> "Hello" examples</p>
 
-    <br><button id="addClassB">Add an Example to Class B</button>
-    <button id="resetB">Reset Class B</button>
-    <p><span id="exampleB">0</span> B examples</p>
-    <p>| Confidence in B is: <span id="confidenceB">0</span></p>
+    <br><button id="addClass2">Add an Example to Class "Goodbye"</button>
+    <p><span id="example2">0</span> "Goodbye" examples</p>
   </p>
   <br/>
   <p>

--- a/p5js/KNNClassification/KNNClassification_VideoSound/lib/p5.speech.js
+++ b/p5js/KNNClassification/KNNClassification_VideoSound/lib/p5.speech.js
@@ -1,0 +1,370 @@
+/*! p5.speech.js v0.0.1 2015-06-12 */
+/* updated v0.0.2 2017-10-17 */
+/**
+ * @module p5.speech
+ * @submodule p5.speech
+ * @for p5.speech
+ * @main
+ */
+/**
+ *  p5.speech
+ *  R. Luke DuBois (dubois@nyu.edu)
+ *  ABILITY Lab / Brooklyn Experimental Media Center
+ *  New York University
+ *  The MIT License (MIT).
+ *  
+ *  https://github.com/IDMNYU/p5.js-speech
+ *
+ *  Web Speech API: https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html
+ *  Web Speech Recognition API: https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html
+ */
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd)
+    define('p5.speech', ['p5'], function (p5) { (factory(p5));});
+  else if (typeof exports === 'object')
+    factory(require('../p5'));
+  else
+    factory(root['p5']);
+}(this, function (p5) {
+// =============================================================================
+//                         p5.Speech
+// =============================================================================
+
+
+  /**
+   * Base class for a Speech Synthesizer
+   *
+   * @class p5.Speech
+   * @constructor
+   */
+  p5.Speech = function(_dv, _callback) {
+
+    //
+    // speech synthesizers consist of a single synthesis engine
+    // per window instance, and a variable number of 'utterance'
+    // objects, which can be cached and re-used for, e.g.
+    // auditory UI.
+    //
+    // this implementation assumes a monolithic (one synth, 
+    // one phrase at a time) system.
+    //
+
+    // make a speech synthizer (this will load voices):
+    this.synth = window.speechSynthesis;
+
+    // make an utterance to use with this synthesizer:
+    this.utterance = new SpeechSynthesisUtterance();
+
+    this.isLoaded = 0; // do we have voices yet?
+
+    // do we queue new utterances upon firing speak() 
+    // or interrupt what's speaking:
+    this.interrupt = false; 
+
+    // callback properties to be filled in within the p5 sketch
+    // if the author needs custom callbacks:
+    this.onLoad; // fires when voices are loaded and synth is ready
+    this.onStart; // fires when an utterance begins...
+    this.onPause; // ...is paused...
+    this.onResume; // ...resumes...
+    this.onEnd; // ...and ends.
+
+    this.voices = []; // array of available voices (dependent on browser/OS)
+
+    // first parameter of constructor is an initial voice selector
+    this.initvoice;
+    if(_dv !== undefined) this.initvoice=_dv;
+    if(_callback !== undefined) this.onLoad =_callback;
+
+    var that = this; // some bullshit
+
+    // onvoiceschanged() fires automatically when the synthesizer
+    // is configured and has its voices loaded.  you don't need
+    // to wait for this if you're okay with the default voice.
+    // 
+    // we use this function to load the voice array and bind our
+    // custom callback functions.
+    window.speechSynthesis.onvoiceschanged = function() {
+      if(that.isLoaded==0) { // run only once
+        that.voices = window.speechSynthesis.getVoices();
+        that.isLoaded = 1; // we're ready
+        console.log("p5.Speech: voices loaded!");
+
+        if(that.initvoice!=undefined) {
+          that.setVoice(that.initvoice); // set a custom initial voice
+          console.log("p5.Speech: initial voice: " + that.initvoice);
+        }
+
+        // fire custom onLoad() callback, if it exists:
+        if(that.onLoad!=undefined) that.onLoad();
+
+        //
+        // bind other custom callbacks:
+        //
+
+        that.utterance.onstart = function(e) {
+          //console.log("STARTED");
+          if(that.onStart!=undefined) that.onStart(e);     
+        };
+        that.utterance.onpause = function(e) {
+          //console.log("PAUSED");
+          if(that.onPause!=undefined) that.onPause(e);
+        };
+        that.utterance.onresume = function(e) {
+          //console.log("RESUMED");
+          if(that.onResume!=undefined) that.onResume(e);
+        };
+        that.utterance.onend = function(e) {
+          //console.log("ENDED");
+          if(that.onEnd!=undefined) that.onEnd(e); 
+        };
+      }
+    };
+
+  };     // end p5.Speech constructor
+
+
+  // listVoices() - dump voice names to javascript console:
+  p5.Speech.prototype.listVoices = function() {
+    if(this.isLoaded)
+    {
+      for(var i = 0;i<this.voices.length;i++)
+      {
+        console.log(this.voices[i].name);
+      }
+    }
+    else
+    {
+    	console.log("p5.Speech: voices not loaded yet!")
+    }
+  };
+
+  // setVoice() - assign voice to speech synthesizer, by name
+  // (using voices found in the voices[] array), or by index.
+  p5.Speech.prototype.setVoice = function(_v) {
+    // type check so you can set by label or by index:
+    if(typeof(_v)=='string') this.utterance.voice = this.voices.filter(function(v) { return v.name == _v; })[0];
+    else if(typeof(_v)=='number') this.utterance.voice = this.voices[Math.min(Math.max(_v,0),this.voices.length-1)];
+  };
+
+  // volume of voice. API range 0.0-1.0.
+  p5.Speech.prototype.setVolume = function(_v) {
+    this.utterance.volume = Math.min(Math.max(_v, 0.0), 1.0);
+  };
+
+  // rate of voice.  not all voices support this feature.
+  // API range 0.1-2.0.  voice will crash out of bounds.
+  p5.Speech.prototype.setRate = function(_v) {
+    this.utterance.rate = Math.min(Math.max(_v, 0.1), 2.0);
+  };
+
+  // pitch of voice.  not all voices support this feature.
+  // API range >0.0-2.0.  voice will crash out of bounds.
+  p5.Speech.prototype.setPitch = function(_v) {
+    this.utterance.pitch = Math.min(Math.max(_v, 0.01), 2.0);
+  };
+
+  // sets the language of the voice.
+  p5.Speech.prototype.setLang = function(_lang) {
+    this.utterance.lang = _lang;
+}
+
+  // speak a phrase through the current synthesizer:
+  p5.Speech.prototype.speak = function(_phrase) {
+    if(this.interrupt) this.synth.cancel();
+    this.utterance.text = _phrase;
+
+    this.synth.speak(this.utterance);
+  };
+
+  // not working...
+  p5.Speech.prototype.pause = function() {
+    this.synth.pause();
+  };
+
+  // not working...
+  p5.Speech.prototype.resume = function() {
+    this.synth.resume();
+  };
+
+  // stop current utterance:
+  p5.Speech.prototype.stop = function() {
+    // not working...
+    //this.synth.stop();
+    this.synth.cancel();
+  };
+
+  // kill synthesizer completely, clearing any queued utterances:
+  p5.Speech.prototype.cancel = function() {
+    this.synth.cancel(); // KILL SYNTH
+  };
+
+  // Setting callbacks with functions instead
+  p5.Speech.prototype.started = function(_cb) {
+   this.onStart = _cb;
+  }
+
+  p5.Speech.prototype.ended = function(_cb) {
+    this.onEnd = _cb;
+  }
+
+  p5.Speech.prototype.paused = function(_cb) {
+    this.onPause = _cb;
+  }
+
+  p5.Speech.prototype.resumed = function(_cb) {
+    this.onResume = _cb;
+  }
+
+// =============================================================================
+//                         p5.SpeechRec
+// =============================================================================
+
+
+  /**
+   * Base class for a Speech Recognizer
+   *
+   * @class p5.SpeechRec
+   * @constructor
+   */
+  p5.SpeechRec = function(_lang, _callback) {
+
+    //
+    // speech recognition consists of a recognizer object per 
+    // window instance that returns a JSON object containing
+    // recognition.  this JSON object grows when the synthesizer
+    // is in 'continuous' mode, with new recognized phrases
+    // appended into an internal array.
+    //
+    // this implementation returns the full JSON, but also a set
+    // of simple, query-ready properties containing the most
+    // recently recognized speech.
+    //
+
+    // make a recognizer object.
+    if('webkitSpeechRecognition' in window) {
+      this.rec = new webkitSpeechRecognition();
+    }
+    else {
+      this.rec = new Object();
+      console.log("p5.SpeechRec: webkitSpeechRecognition not supported in this browser.");
+    }
+
+    // first parameter is language model (defaults to empty=U.S. English)
+    // no list of valid models in API, but it must use BCP-47.
+    // here's some hints:
+    // http://stackoverflow.com/questions/14257598/what-are-language-codes-for-voice-recognition-languages-in-chromes-implementati
+    if(_lang !== undefined) this.rec.lang=_lang;
+
+    // callback properties to be filled in within the p5 sketch
+    // if the author needs custom callbacks:
+    this.onResult; // fires when something has been recognized
+    this.onStart; // fires when the recognition system is started...
+    this.onError; // ...has a problem (e.g. the mic is shut off)...
+    this.onEnd; // ...and ends (in non-continuous mode).
+    if(_callback !== undefined) this.onResult=_callback;
+
+    // recognizer properties:
+
+    // continous mode means the object keeps recognizing speech,
+    // appending new tokens to the internal JSON.
+    this.continuous = false; 
+    // interimResults means the object will report (i.e. fire its
+    // onresult() callback) more frequently, rather than at pauses
+    // in microphone input.  this gets you quicker, but less accurate,
+    // results.
+    this.interimResults = false;
+
+    // result data:
+
+    // resultJSON:
+    // this is a full JSON returned by onresult().  it consists of a 
+    // SpeechRecognitionEvent object, which contains a (wait for it)
+    // SpeechRecognitionResultList.  this is an array.  in continuous
+    // mode, it will be appended to, not cleared.  each element is a 
+    // SpeechRecognition result, which contains a (groan)
+    // SpeechRecognitionAlternative, containing a 'transcript' property.
+    // the 'transcript' is the recognized phrase.  have fun.
+    this.resultJSON; 
+    // resultValue:
+    // validation flag which indicates whether the recognizer succeeded.  
+    // this is *not* a metric of speech clarity, but rather whether the
+    // speech recognition system successfully connected to and received
+    // a response from the server.  you can construct an if() around this
+    // if you're feeling worried.
+    this.resultValue; 
+    // resultValue:
+    // the 'transcript' of the most recently recognized speech as a simple
+    // string.  this will be blown out and replaced at every firing of the
+    // onresult() callback.
+    this.resultString; 
+    // resultConfidence:
+    // the 'confidence' (0-1) of the most recently recognized speech, e.g.
+    // that it reflects what was actually spoken.  you can use this to filter
+    // out potentially bogus recognition tokens.
+    this.resultConfidence; 
+
+    var that = this; // some bullshit
+
+    // onresult() fires automatically when the recognition engine
+    // detects speech, or times out trying.
+    // 
+    // it fills up a JSON array internal to the webkitSpeechRecognition
+    // object.  we reference it over in our struct here, and also copy 
+    // out the most recently detected phrase and confidence value.
+    this.rec.onresult = function(e) { 
+      that.resultJSON = e; // full JSON of callback event
+      that.resultValue = e.returnValue; // was successful?
+      // store latest result in top-level object struct
+      that.resultString = e.results[e.results.length-1][0].transcript.trim();
+      that.resultConfidence = e.results[e.results.length-1][0].confidence;
+      if(that.onResult!=undefined) that.onResult();
+    };
+
+    // fires when the recognition system starts (i.e. when you 'allow'
+    // the mic to be used in the browser).
+    this.rec.onstart = function(e) {
+      if(that.onStart!=undefined) that.onStart(e);
+    };
+    // fires on a client-side error (server-side errors are expressed 
+    // by the resultValue in the JSON coming back as 'false').
+    this.rec.onerror = function(e) {
+      if(that.onError!=undefined) that.onError(e);
+    };
+    // fires when the recognition finishes, in non-continuous mode.
+    this.rec.onend = function() {
+      if(that.onEnd!=undefined) that.onEnd();
+    };
+
+  }; // end p5.SpeechRec constructor
+
+  // start the speech recognition engine.  this will prompt a 
+  // security dialog in the browser asking for permission to 
+  // use the microphone.  this permission will persist throughout
+  // this one 'start' cycle.  if you need to recognize speech more
+  // than once, use continuous mode rather than firing start() 
+  // multiple times in a single script.
+  p5.SpeechRec.prototype.start = function(_continuous, _interim) {
+    if('webkitSpeechRecognition' in window) {
+      if(_continuous !== undefined) this.continuous = _continuous;
+      if(_interim !== undefined) this.interimResults = _interim;
+      this.rec.continuous = this.continuous;
+      this.rec.interimResults = this.interimResults;
+      this.rec.start();
+    }
+  };
+
+}));
+
+/*
+todo:
+* fix callbacks (pause, resume) in synthesizer.
+* support speech grammar models for scoped auditory UI.
+* support markdown, boundaries, etc for better synthesis tracking.
+* support utterance parser for long phrases.
+*/
+
+// EOF
+
+
+

--- a/p5js/KNNClassification/KNNClassification_VideoSound/sketch.js
+++ b/p5js/KNNClassification/KNNClassification_VideoSound/sketch.js
@@ -1,0 +1,125 @@
+// Copyright (c) 2018 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/* ===
+ml5 Example
+KNN Classification on Webcam Images with mobileNet. Built with p5.js
+=== */
+let video;
+// Create a KNN classifier
+const knnClassifier = ml5.KNNClassifier();
+
+let featureExtractor;
+let currentWord;
+let myVoice;
+
+function setup() {
+  // Create a featureExtractor that can extract the already learned features from MobileNet
+  featureExtractor = ml5.featureExtractor('MobileNet', modelReady);
+  noCanvas();
+  // Create a video element
+  video = createCapture(VIDEO);
+  // Append it to the videoContainer DOM element
+  video.parent('videoContainer');
+  // Create the UI buttons
+  createButtons();
+  // Speech synthesis object
+  myVoice = new p5.Speech();
+  // The speak() method will interrupt existing speech currently being synthesized.
+  myVoice.interrupt = true;
+}
+
+function modelReady() {
+  select('#status').html('FeatureExtractor(mobileNet model) Loaded')
+}
+
+// Add the current frame from the video to the classifier
+function addExample(label) {
+  // Get the features of the input video
+  const features = featureExtractor.infer(video);
+
+  // Add an example with a label to the classifier
+  knnClassifier.addExample(features, label);
+  updateCounts();
+}
+
+// Predict the current frame.
+function classify() {
+  // Get the total number of labels from knnClassifier
+  const numLabels = knnClassifier.getNumLabels();
+  if (numLabels <= 0) {
+    console.error('There is no examples in any label');
+    return;
+  }
+  // Get the features of the input video
+  const features = featureExtractor.infer(video);
+
+  // Use knnClassifier to classify which label do these features belong to
+  // You can pass in a callback function `gotResults` to knnClassifier.classify function
+  knnClassifier.classify(features, gotResults);
+}
+
+// A util function to create UI buttons
+function createButtons() {
+  // When the A button is pressed, add the current frame to class "Hello"
+  buttonA = select('#addClass1');
+  buttonA.mousePressed(function() {
+    addExample('Hello');
+  });
+
+  // When the B button is pressed, add the current frame to class "goodbye"
+  buttonB = select('#addClass2');
+  buttonB.mousePressed(function() {
+    addExample('Goodbye');
+  });
+
+  // Predict button
+  buttonPredict = select('#buttonPredict');
+  buttonPredict.mousePressed(classify);
+
+  // Clear all classes button
+  buttonClearAll = select('#clearAll');
+  buttonClearAll.mousePressed(clearAllLabels);
+}
+
+// Show the results
+function gotResults(err, result) {
+  // Display any error
+  if (err) {
+    console.error(err);
+  }
+
+  if (result.confidencesByLabel) {
+    const confidences = result.confidencesByLabel;
+    // result.label is the label that has the highest confidence
+    if (result.label) {
+      select('#result').html(result.label);
+      select('#confidence').html(`${confidences[result.label] * 100} %`);
+
+      // If the confidence is higher then 0.9
+      if (result.label !== currentWord && confidences[result.label] > 0.9) {
+        currentWord = result.label;
+        // Say the current word 
+        myVoice.speak(currentWord);
+      }
+    }
+  }
+
+  classify();
+}
+
+// Update the example count for each class	
+function updateCounts() {
+  const counts = knnClassifier.getCountByLabel();
+
+  select('#example1').html(counts['Hello'] || 0);
+  select('#example2').html(counts['Goodbye'] || 0);
+}
+
+// Clear all the examples in all classes
+function clearAllLabels() {
+  knnClassifier.clearAllLabels();
+  updateCounts();
+}

--- a/p5js/KNNClassification/KNNClassification_VideoSquare/index.html
+++ b/p5js/KNNClassification/KNNClassification_VideoSquare/index.html
@@ -1,0 +1,68 @@
+<!--
+ Copyright (c) 2018 ml5
+ 
+ This software is released under the MIT License.
+ https://opensource.org/licenses/MIT
+-->
+
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>KNN Classification on Webcam Images with mobileNet. Built with p5.js</title>
+  
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/addons/p5.dom.min.js"></script>
+  <script src="https://unpkg.com/ml5@0.2.1/dist/ml5.min.js" type="text/javascript"></script>
+  
+  <style>
+  button {
+    margin: 6px 6px 6px 0;
+    padding: 4px;
+    font-size: 14px;
+  }
+  video {
+    width: 300;
+    height: 300;
+  }
+  p {
+    display: inline;
+    font-size: 16px;
+  }
+  .emoji {
+    font-size: 24px;
+  }
+  </style>
+</head>
+
+<body>
+  <h2>KNN Classification on Webcam Images that moves a square on the canvas with mobileNet. Built with p5.js</h2>
+  <div id="canvasContainer"></div>
+  <p id="status">Loading Model...</p><br>
+  <p>
+    <span class="emoji"> ⬆️ </span><button id="addClass1">Add an Example to Class Up</button>
+    <p><span id="example1">0</span> Up examples</p>
+
+    <br><span class="emoji"> ➡️ </span><button id="addClass2">Add an Example to Class Right</button>
+    <p><span id="example2">0</span> Right examples</p>
+
+    <br><span class="emoji"> ⬇️ </span><button id="addClass3">Add an Example to Class Down</button>
+    <p><span id="example3">0</span> Down examples</p>
+
+    <br><span class="emoji"> ⬅️ </span><button id="addClass4">Add an Example to Class Left</button>
+    <p><span id="example4">0</span> Left examples</p>
+  </p>
+  <br/>
+  <p>
+    <button id="buttonPredict">Start predicting!</button><br>
+    <button id="clearAll">Clear all classes</button><br>
+  </p>
+  <p>
+    KNN Classifier with mobileNet model labeled this
+    as Class: <span id="result">...</span>
+    with a confidence of <span id="confidence">...</span>
+  </p>
+  <script src="sketch.js"></script>
+</body>
+
+</html>

--- a/p5js/KNNClassification/KNNClassification_VideoSquare/sketch.js
+++ b/p5js/KNNClassification/KNNClassification_VideoSquare/sketch.js
@@ -1,0 +1,177 @@
+// Copyright (c) 2018 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/* ===
+ml5 Example
+KNN Classification on Webcam Images with mobileNet. Built with p5.js
+=== */
+let video;
+let posX;
+let posY;
+const squareSize = 100;
+// Create a KNN classifier
+const knnClassifier = ml5.KNNClassifier();
+let featureExtractor;
+
+function setup() {
+  // Create a featureExtractor that can extract the already learned features from MobileNet
+  featureExtractor = ml5.featureExtractor('MobileNet', modelReady);
+
+  const canvas = createCanvas(640, 480);
+  posX = width / 2;
+  posY = height / 2;
+  // Put the canvas into the <div id="canvasContainer"></div>.
+  canvas.parent('#canvasContainer')
+  // Create a video element
+  video = createCapture(VIDEO);
+  video.size(width, height);
+  // Hide the video element, and just show the canvas
+  video.hide();
+  // Create the UI buttons
+  createButtons();
+  noStroke();
+  fill(255, 0, 0);
+}
+
+function draw() {
+  // Flip the video from left to right, mirror the video
+  translate(width, 0)
+  scale(-1, 1);
+  image(video, 0, 0, width, height);
+
+  // draw a square on the canvas
+  rect(posX, posY, squareSize, squareSize);
+}
+
+function modelReady(){
+  select('#status').html('FeatureExtractor(mobileNet model) Loaded')
+}
+
+// Add the current frame from the video to the classifier
+function addExample(label) {
+  // Get the features of the input video
+  const features = featureExtractor.infer(video);
+
+  // Add an example with a label to the classifier
+  knnClassifier.addExample(features, label);
+  updateCounts();
+}
+
+// Predict the current frame.
+function classify() {
+  // Get the total number of labels from knnClassifier
+  const numLabels = knnClassifier.getNumLabels();
+  if (numLabels <= 0) {
+    console.error('There is no examples in any label');
+    return;
+  }
+  // Get the features of the input video
+  const features = featureExtractor.infer(video);
+
+  // Use knnClassifier to classify which label do these features belong to
+  knnClassifier.classify(features, gotResults);
+}
+
+// A util function to create UI buttons
+function createButtons() {
+  // When the addClass1 button is pressed, add the current frame to class "Up"
+  buttonA = select('#addClass1');
+  buttonA.mousePressed(function() {
+    addExample('Up');
+  });
+
+  // When the addClass2 button is pressed, add the current frame to class "Right"
+  buttonB = select('#addClass2');
+  buttonB.mousePressed(function() {
+    addExample('Right');
+  });
+
+  // When the addClass3 button is pressed, add the current frame to class "Down"
+  buttonC = select('#addClass3');
+  buttonC.mousePressed(function() {
+    addExample('Down');
+  });
+
+  // When the addClass4 button is pressed, add the current frame to class "Left"
+  buttonC = select('#addClass4');
+  buttonC.mousePressed(function() {
+    addExample('Left');
+  });
+
+  // Predict button
+  buttonPredict = select('#buttonPredict');
+  buttonPredict.mousePressed(classify);
+
+  // Clear all classes button
+  buttonClearAll = select('#clearAll');
+  buttonClearAll.mousePressed(clearAllLabels);
+}
+
+// Show the results
+function gotResults(err, result) {
+  // Display any error
+  if (err) {
+    console.error(err);
+  }
+
+  if (result.confidencesByLabel) {
+    const confidences = result.confidencesByLabel;
+    // result.label is the label that has the highest confidence
+    if (result.label) {
+      select('#result').html(result.label);
+      select('#confidence').html(`${confidences[result.label] * 100} %`);
+
+      switch(result.label) {
+        case 'Up':
+          posY-=2;
+          break;
+
+        case 'Down':
+          posY+=2;
+          break;
+
+        case 'Left':
+          posX+=2;
+          break;
+
+        case 'Right':
+          posX-=2;
+          break;
+        
+        default:
+          console.log(`Sorry, unknown label: ${result.label}`);
+      }
+      // Border checking
+      if (posY < 0) posY = 0;
+      if (posY > height - squareSize) posY = height - squareSize;
+      if (posX < 0) posX = 0;
+      if (posX > width - squareSize) posX = width - squareSize;
+    }
+  }
+
+  classify();
+}
+
+// Update the example count for each class	
+function updateCounts() {
+  const counts = knnClassifier.getCountByLabel();
+
+  select('#example1').html(counts['Up'] || 0);
+  select('#example2').html(counts['Right'] || 0);
+  select('#example3').html(counts['Down'] || 0);
+  select('#example4').html(counts['Left'] || 0);
+}
+
+// Clear the examples in one class
+function clearLabel(classLabel) {
+  knnClassifier.clearLabel(classLabel);
+  updateCounts();
+}
+
+// Clear all the examples in all classes
+function clearAllLabels() {
+  knnClassifier.clearAllLabels();
+  updateCounts();
+}


### PR DESCRIPTION
This PR -
- adds a KNN Classifier with speech output example([demo](https://yining1023.github.io/machine-learning-for-the-web/week5-moreExamples/KNNClassification_VideoSound/))
- adds a KNN Classifier with moving square(up, down, left, right) on a canvas example([demo](https://yining1023.github.io/machine-learning-for-the-web/week5-moreExamples/KNNClassification_VideoSquare/))
- update the existing 2 KNN examples pointing to ml5@0.2.1

(There is a p5.speech.js(13KB) soure file in one of the examples, but I open an issue on p5.speech to see if there could be a CDN link for p5.speech)