### PR TITLE
Update ImageClassifier and FeatureExtractor to return {label, confidence}

### DIFF
--- a/javascript/FeatureExtractor_Image_Classification/index.html
+++ b/javascript/FeatureExtractor_Image_Classification/index.html
@@ -11,7 +11,8 @@
   <meta charset="UTF-8">
   <title>Image Classification using Feature Extraction with MobileNet</title>
 
-  <script src="https://unpkg.com/ml5" type="text/javascript"></script>
+  <!-- <script src="https://unpkg.com/ml5" type="text/javascript"></script> -->
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 
   <style>
   button {
@@ -53,6 +54,7 @@
   <p>
     <button id="predict">Start guessing!</button><br>
     My guess is: <span id="result">...</span>
+    , with a confidence of <span id="confidence">...</span>.
   </p>
   <script src="sketch.js"></script>
 </body>

--- a/javascript/FeatureExtractor_Image_Classification/sketch.js
+++ b/javascript/FeatureExtractor_Image_Classification/sketch.js
@@ -26,12 +26,11 @@ var predict = document.getElementById('predict');
 let totalLoss = 0;
 
 // Create a webcam capture
-if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
-  navigator.mediaDevices.getUserMedia({ video: true }).then(function(stream) {
-    video.src = window.URL.createObjectURL(stream);
+navigator.mediaDevices.getUserMedia({ video: true })
+  .then((stream) => {
+    video.srcObject = stream;
     video.play();
-  });
-}
+  })
 
 // A function to be called when the model has been loaded
 function modelLoaded() {
@@ -87,9 +86,9 @@ function gotResults(err, results) {
     console.error(err);
   }
   if (results && results[0]) {
-    select('#result').html(results[0].label);
-    select('#confidence').html(results[0].confidence);
-    classify();
+    result.innerText = results[0].label;
+    confidence.innerText = results[0].confidence;
+    classifier.classify(gotResults);
   }
 }
 

--- a/javascript/FeatureExtractor_Image_Classification/sketch.js
+++ b/javascript/FeatureExtractor_Image_Classification/sketch.js
@@ -19,6 +19,7 @@ var amountOfDogImages = document.getElementById('amountOfDogImages');
 var train = document.getElementById('train');
 var loss = document.getElementById('loss');
 var result = document.getElementById('result');
+var confidence = document.getElementById('confidence');
 var predict = document.getElementById('predict');
 
 // A variable to store the total loss
@@ -80,13 +81,16 @@ train.onclick = function () {
 }
 
 // Show the results
-function gotResults(err, data) {
+function gotResults(err, results) {
   // Display any error
   if (err) {
     console.error(err);
   }
-  result.innerText = data;
-  classifier.classify(gotResults);
+  if (results && results[0]) {
+    select('#result').html(results[0].label);
+    select('#confidence').html(results[0].confidence);
+    classify();
+  }
 }
 
 // Start predicting when the predict button is clicked

--- a/javascript/ImageClassification/index.html
+++ b/javascript/ImageClassification/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Image Classification Example</title>
 
-  <script src="https://unpkg.com/ml5@0.1.1/dist/ml5.min.js" type="text/javascript"></script>
-  
+  <!-- <script src="https://unpkg.com/ml5@0.1.1/dist/ml5.min.js" type="text/javascript"></script> -->
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/javascript/ImageClassification/sketch.js
+++ b/javascript/ImageClassification/sketch.js
@@ -17,6 +17,6 @@ const probability = document.getElementById('probability'); // The probability t
 ml5.imageClassifier('MobileNet')
   .then(classifier => classifier.predict(image))
   .then(results => {
-    result.innerText = results[0].className;
-    probability.innerText = results[0].probability.toFixed(4);
+    result.innerText = results[0].label;
+    probability.innerText = results[0].confidence.toFixed(4);
   });

--- a/javascript/ImageClassification/sketch.js
+++ b/javascript/ImageClassification/sketch.js
@@ -15,7 +15,7 @@ const probability = document.getElementById('probability'); // The probability t
 
 // Initialize the Image Classifier method with MobileNet
 ml5.imageClassifier('MobileNet')
-  .then(classifier => classifier.predict(image))
+  .then(classifier => classifier.classify(image))
   .then(results => {
     result.innerText = results[0].label;
     probability.innerText = results[0].confidence.toFixed(4);

--- a/javascript/ImageClassification_Video/index.html
+++ b/javascript/ImageClassification_Video/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Webcam Image Classification using MobileNet</title>
 
-  <script src="https://unpkg.com/ml5@0.1.1/dist/ml5.min.js" type="text/javascript"></script>
-  
+  <!-- <script src="https://unpkg.com/ml5@0.1.1/dist/ml5.min.js" type="text/javascript"></script> -->
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/javascript/ImageClassification_Video/sketch.js
+++ b/javascript/ImageClassification_Video/sketch.js
@@ -25,7 +25,7 @@ ml5.imageClassifier('MobileNet', video)
   .then(classifier => loop(classifier))
 
 const loop = (classifier) => {
-  classifier.predict()
+  classifier.classify()
     .then(results => {
       result.innerText = results[0].label;
       probability.innerText = results[0].confidence.toFixed(4);

--- a/javascript/ImageClassification_Video/sketch.js
+++ b/javascript/ImageClassification_Video/sketch.js
@@ -27,8 +27,8 @@ ml5.imageClassifier('MobileNet', video)
 const loop = (classifier) => {
   classifier.predict()
     .then(results => {
-      result.innerText = results[0].className;
-      probability.innerText = results[0].probability.toFixed(4);
+      result.innerText = results[0].label;
+      probability.innerText = results[0].confidence.toFixed(4);
       loop(classifier) // Call again to create a loop
     })
 }

--- a/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/index.html
+++ b/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/index.html
@@ -13,8 +13,8 @@
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
-  
+  <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   <style>
   button {
     margin: 2px;
@@ -53,7 +53,8 @@
   <br/>
   <p>
     <button id="buttonPredict">Start guessing!</button><br>
-    Your custom model labeled this as: <span id="result">...</span>
+    Your custom model labeled this as: <span id="result">...</span>,
+    with a confidence of <span id="confidence">...</span>.
   </p>
   <br/>
   <br>

--- a/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/index.html
+++ b/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Image Classification using Feature Extraction with MobileNet. Built with p5.js</title>
   
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   <style>

--- a/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/sketch.js
+++ b/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/sketch.js
@@ -99,11 +99,14 @@ function setupButtons() {
 }
 
 // Show the results
-function gotResults(err, result) {
+function gotResults(err, results) {
   // Display any error
   if (err) {
     console.error(err);
   }
-  select('#result').html(result);
-  classify();
+  if (results && results[0]) {
+    select('#result').html(results[0].label);
+    select('#confidence').html(results[0].confidence);
+    classify();
+  }
 }

--- a/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/index.html
+++ b/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/index.html
@@ -13,8 +13,8 @@
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
-
+  <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   
   
   <style>

--- a/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/index.html
+++ b/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Image Regression using Feature Extraction with MobileNet. Built with p5.js</title>
   
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   

--- a/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/sketch.js
+++ b/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/sketch.js
@@ -83,7 +83,9 @@ function gotResults(err, result) {
   if (err) {
     console.error(err);
   }
-  positionX = map(result, 0, 1, 0, width);
-  slider.value(result);
-  predict();
+  if (result && result.value) {
+    positionX = map(result.value, 0, 1, 0, width);
+    slider.value(result.value);
+    predict();
+  }
 }

--- a/p5js/ImageClassification/ImageClassification/index.html
+++ b/p5js/ImageClassification/ImageClassification/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Image classification using MobileNet and p5.js</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 </head>

--- a/p5js/ImageClassification/ImageClassification/index.html
+++ b/p5js/ImageClassification/ImageClassification/index.html
@@ -13,8 +13,8 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
-
+  <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/ImageClassification/ImageClassification/sketch.js
+++ b/p5js/ImageClassification/ImageClassification/sketch.js
@@ -30,9 +30,9 @@ function modelReady(){
 // When the image has been loaded,
 // get a prediction for that image
 function imageReady() {
-  classifier.predict(img, gotResult);
+  classifier.classify(img, gotResult);
   // You can also specify the amount of classes you want
-  // classifier.predict(img, 10, gotResult);
+  // classifier.classify(img, 10, gotResult);
 }
 
 // A function to run when we get any errors and the results

--- a/p5js/ImageClassification/ImageClassification/sketch.js
+++ b/p5js/ImageClassification/ImageClassification/sketch.js
@@ -41,7 +41,7 @@ function gotResult(err, results) {
   if (err) {
     console.error(err);
   }
-  // The results are in an array ordered by probability.
-  select('#result').html(results[0].className);
-  select('#probability').html(nf(results[0].probability, 0, 2));
+  // The results are in an array ordered by confidence.
+  select('#result').html(results[0].label);
+  select('#probability').html(nf(results[0].confidence, 0, 2));
 }

--- a/p5js/ImageClassification/ImageClassification_MultipleImages/index.html
+++ b/p5js/ImageClassification/ImageClassification_MultipleImages/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <title>Multiple Image classification using MobileNet and p5.js</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 </head>

--- a/p5js/ImageClassification/ImageClassification_MultipleImages/index.html
+++ b/p5js/ImageClassification/ImageClassification_MultipleImages/index.html
@@ -6,8 +6,8 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
-  
+  <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/ImageClassification/ImageClassification_MultipleImages/sketch.js
+++ b/p5js/ImageClassification/ImageClassification_MultipleImages/sketch.js
@@ -46,7 +46,7 @@ function drawNextImage() {
 // When the image has been loaded,
 // get a prediction for that image
 function imageReady() {
-  classifier.predict(img, gotResult);
+  classifier.classify(img, gotResult);
 }
 
 function savePredictions() {
@@ -78,9 +78,9 @@ function gotResult(err, results) {
   }
   predictions.push(information);
   if (display) {
-    // The results are in an array ordered by probability.
-    select('#result').html(results[0].className);
-    select('#probability').html(nf(results[0].probability, 0, 2));
+    // The results are in an array ordered by confidence.
+    select('#result').html(results[0].label);
+    select('#probability').html(nf(results[0].confidence, 0, 2));
     // Can be changed with the displayTime variable.
     setTimeout(removeImage, displayTime);
   } else {

--- a/p5js/ImageClassification/ImageClassification_Video/index.html
+++ b/p5js/ImageClassification/ImageClassification_Video/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Webcam Image Classification using MobileNet and p5.js</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 </head>

--- a/p5js/ImageClassification/ImageClassification_Video/index.html
+++ b/p5js/ImageClassification/ImageClassification_Video/index.html
@@ -13,8 +13,8 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
-  
+  <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/ImageClassification/ImageClassification_Video/sketch.js
+++ b/p5js/ImageClassification/ImageClassification_Video/sketch.js
@@ -29,13 +29,13 @@ function modelReady() {
 
 // Get a prediction for the current video frame
 function classifyVideo() {
-  classifier.predict(gotResult);
+  classifier.classify(gotResult);
 }
 
 // When we get a result
 function gotResult(err, results) {
-  // The results are in an array ordered by probability.
-  select('#result').html(results[0].className);
-  select('#probability').html(nf(results[0].probability, 0, 2));
+  // The results are in an array ordered by confidence.
+  select('#result').html(results[0].label);
+  select('#probability').html(nf(results[0].confidence, 0, 2));
   classifyVideo();
 }

--- a/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
+++ b/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
@@ -13,7 +13,8 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script>
+  <!-- <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script> -->
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   <script src="lib/p5.speech.js"></script>
   
 </head>

--- a/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
+++ b/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Webcam Image Classification with Speech Output using MobileNet, p5.js, p5.speech</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <!-- <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script> -->
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   <script src="lib/p5.speech.js"></script>

--- a/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/sketch.js
+++ b/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/sketch.js
@@ -59,19 +59,19 @@ function modelReady() {
 
 // Get a prediction for the current video frame
 function classifyVideo() {
-  classifier.predict(gotResult);
+  classifier.classify(gotResult);
 }
 
 // When we get a result
 function gotResult(err, results) {
-  // The results are in an array ordered by probability.
+  // The results are in an array ordered by confidence.
   // Get the first result string
-  const result = results[0].className;
+  const result = results[0].label;
   // Split the first result string by coma and get the first word
   const oneWordRes = result.split(',')[0];
   // Get the top 3 results as strings in an array
   // Read more about map function here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
-  const top3Res = results.map(r => r.className);
+  const top3Res = results.map(r => r.label);
   // Find if any of the top 3 result strings includes the current word
   // Read more about find function here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
   const ifFound = top3Res.find(r => r.includes(currentWord))

--- a/p5js/ImageClassification/ImageClassification_VideoSound/index.html
+++ b/p5js/ImageClassification/ImageClassification_VideoSound/index.html
@@ -13,7 +13,8 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script>
+  <!-- <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script> -->
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   <script src="lib/p5.speech.js"></script>
   
 </head>

--- a/p5js/ImageClassification/ImageClassification_VideoSound/index.html
+++ b/p5js/ImageClassification/ImageClassification_VideoSound/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Webcam Image Classification with Speech Output using MobileNet, p5.js, p5.speech</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <!-- <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script> -->
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   <script src="lib/p5.speech.js"></script>

--- a/p5js/ImageClassification/ImageClassification_VideoSound/sketch.js
+++ b/p5js/ImageClassification/ImageClassification_VideoSound/sketch.js
@@ -33,14 +33,14 @@ function modelReady() {
 
 // Get a prediction for the current video frame
 function classifyVideo() {
-  classifier.predict(gotResult);
+  classifier.classify(gotResult);
 }
 
 // When we get a result
 function gotResult(err, results) {
-  // The results are in an array ordered by probability.
-  select('#result').html(results[0].className);
-  select('#probability').html(nf(results[0].probability, 0, 2));
-  myVoice.speak(`I see ${results[0].className}`);
+  // The results are in an array ordered by confidence.
+  select('#result').html(results[0].label);
+  select('#probability').html(nf(results[0].confidence, 0, 2));
+  myVoice.speak(`I see ${results[0].label}`);
   classifyVideo();
 }

--- a/p5js/ImageClassification/ImageClassification_VideoSoundTranslate/index.html
+++ b/p5js/ImageClassification/ImageClassification_VideoSoundTranslate/index.html
@@ -14,8 +14,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/p5.min.js"></script>
   <script src="lib/p5.speech.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script>
-  
+  <!-- <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script> -->
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/ImageClassification/ImageClassification_VideoSoundTranslate/index.html
+++ b/p5js/ImageClassification/ImageClassification_VideoSoundTranslate/index.html
@@ -11,9 +11,9 @@
   <meta charset="UTF-8">
   <title>Webcam Image Classification with Speech Output using MobileNet, p5.js, p5.speech, google translate API</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="lib/p5.speech.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <!-- <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script> -->
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 </head>

--- a/p5js/ImageClassification/ImageClassification_VideoSoundTranslate/sketch.js
+++ b/p5js/ImageClassification/ImageClassification_VideoSoundTranslate/sketch.js
@@ -46,15 +46,15 @@ function modelReady() {
 
 // Get a prediction for the current video frame
 function classifyVideo() {
-  classifier.predict(gotResult);
+  classifier.classify(gotResult);
 }
 
 // When we get a result
 function gotResult(err, results) {
-  // The results are in an array ordered by probability.
-  const resultText = results[0].className;
+  // The results are in an array ordered by confidence.
+  const resultText = results[0].label;
   select('#result').html(resultText);
-  select('#probability').html(nf(results[0].probability, 0, 2));
+  select('#probability').html(nf(results[0].confidence, 0, 2));
 
   // Get the first word of the result
   const resultWord = resultText.split(',')[0];

--- a/p5js/KNNClassification/KNNClassification_PoseNet/index.html
+++ b/p5js/KNNClassification/KNNClassification_PoseNet/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>PoseNet with KNN Classification on Webcam Images. Built with p5.js</title>
   
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.2.1/dist/ml5.min.js" type="text/javascript"></script>
 
   <style>

--- a/p5js/KNNClassification/KNNClassification_Video/index.html
+++ b/p5js/KNNClassification/KNNClassification_Video/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>KNN Classification on Webcam Images with mobileNet. Built with p5.js</title>
   
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.2.1/dist/ml5.min.js" type="text/javascript"></script>
   
   <style>

--- a/p5js/KNNClassification/KNNClassification_VideoSound/index.html
+++ b/p5js/KNNClassification/KNNClassification_VideoSound/index.html
@@ -11,9 +11,9 @@
   <meta charset="UTF-8">
   <title>KNN Classification on Webcam Images with Speech Output Using mobileNet. Built with p5.js</title>
   
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="lib/p5.speech.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.2.1/dist/ml5.min.js" type="text/javascript"></script>
   
   <style>

--- a/p5js/KNNClassification/KNNClassification_VideoSquare/index.html
+++ b/p5js/KNNClassification/KNNClassification_VideoSquare/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>KNN Classification on Webcam Images with mobileNet. Built with p5.js</title>
   
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.2.1/dist/ml5.min.js" type="text/javascript"></script>
   
   <style>

--- a/p5js/LSTM/LSTM_Interactive/index.html
+++ b/p5js/LSTM/LSTM_Interactive/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Interactive LSTM Text Generation Example using p5.js</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
 
   <style>

--- a/p5js/LSTM/LSTM_Text/index.html
+++ b/p5js/LSTM/LSTM_Text/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>LSTM Text Generation Example</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>

--- a/p5js/LSTM/LSTM_Text_Stateful/index.html
+++ b/p5js/LSTM/LSTM_Text_Stateful/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Stateful LSTM Text Generation Example using p5.js</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
 
 

--- a/p5js/PitchDetection/PitchDetection/index.html
+++ b/p5js/PitchDetection/PitchDetection/index.html
@@ -13,9 +13,9 @@
   <meta charset="UTF-8">
 
   <title>Pitch Detection</title>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.sound.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.sound.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>

--- a/p5js/PitchDetection/PitchDetection_Game/index.html
+++ b/p5js/PitchDetection/PitchDetection_Game/index.html
@@ -5,9 +5,9 @@
   <meta charset="UTF-8">
 
   <title>Pitch Tone Game</title>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.sound.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.sound.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>

--- a/p5js/PitchDetection/PitchDetection_Piano/index.html
+++ b/p5js/PitchDetection/PitchDetection_Piano/index.html
@@ -5,9 +5,9 @@
   <meta charset="UTF-8">
 
   <title>Pitch Detect Piano</title>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.sound.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.sound.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>

--- a/p5js/Pix2Pix/Pix2Pix_callback/index.html
+++ b/p5js/Pix2Pix/Pix2Pix_callback/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Pix2Pix Edges2Pikachu Example</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
 
   <style>

--- a/p5js/Pix2Pix/Pix2Pix_promise/index.html
+++ b/p5js/Pix2Pix/Pix2Pix_promise/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Pix2Pix Edges2Pikachu Example</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
 
   <style>

--- a/p5js/PoseNet/PoseNet_image_single/index.html
+++ b/p5js/PoseNet/PoseNet_image_single/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>PoseNet example on image with single detection using p5.js</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.2/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>

--- a/p5js/PoseNet/PoseNet_webcam/index.html
+++ b/p5js/PoseNet/PoseNet_webcam/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>PoseNet example using p5.js</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>

--- a/p5js/SketchRNN/SketchRNN_basic/index.html
+++ b/p5js/SketchRNN/SketchRNN_basic/index.html
@@ -10,8 +10,8 @@
     <meta charset="UTF-8" />
     <title>SketchRNN</title>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
     <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
     <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   </head>

--- a/p5js/SketchRNN/SketchRNN_interactive/index.html
+++ b/p5js/SketchRNN/SketchRNN_interactive/index.html
@@ -10,8 +10,8 @@
     <meta charset="UTF-8" />
     <title>SketchRNN</title>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
     <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
     <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   </head>

--- a/p5js/StyleTransfer/StyleTransfer_Image/index.html
+++ b/p5js/StyleTransfer/StyleTransfer_Image/index.html
@@ -11,8 +11,8 @@
   <meta charset="UTF-8">
   <title>Style Transfer Image Example using p5.js</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
   
   <style>

--- a/p5js/StyleTransfer/StyleTransfer_Video/index.html
+++ b/p5js/StyleTransfer/StyleTransfer_Video/index.html
@@ -10,8 +10,8 @@
   <meta charset="UTF-8">
   <title>Style Transfer Mirror Example using p5.js</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
   
   <style>

--- a/p5js/Word2Vec/index.html
+++ b/p5js/Word2Vec/index.html
@@ -14,8 +14,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Word2Vec example with p5.js. Using a pre-trained model on common English words.</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
   
 

--- a/p5js/YOLO/index.html
+++ b/p5js/YOLO/index.html
@@ -12,8 +12,8 @@
   <title>Real time Object Detection using YOLO and p5.js</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.0/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>


### PR DESCRIPTION
This PR updates some of the examples in the p5js and javascript folders.

- image classifier (plain MobileNet) example: use`.classify()` instead of `.predict()`
- image classifier (plain MobileNet) example:  returns `[{label, confidence}]` instead of `[{className, probability}]`
- feature extractor classifier example: returns `[{label, confidence}]` instead of just a label.
- feature extractorregressor example: returns `{value: a number}` instead of just a number.

- Also fixed a issue in `javascript/FeatureExtractor_Image_Classification` the video is not showing up issue.
