### PR TITLE
Cleaning up ml5 versions

### DIFF
--- a/javascript/FeatureExtractor_Image_Classification/index.html
+++ b/javascript/FeatureExtractor_Image_Classification/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <title>Image Classification using Feature Extraction with MobileNet</title>
 
-  <!-- <script src="https://unpkg.com/ml5" type="text/javascript"></script> -->
+
   <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
 
   <style>

--- a/javascript/ImageClassification/index.html
+++ b/javascript/ImageClassification/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <title>Image Classification Example</title>
 
-  <!-- <script src="https://unpkg.com/ml5@0.1.1/dist/ml5.min.js" type="text/javascript"></script> -->
+
   <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 

--- a/javascript/ImageClassification_Video/index.html
+++ b/javascript/ImageClassification_Video/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <title>Webcam Image Classification using MobileNet</title>
 
-  <!-- <script src="https://unpkg.com/ml5@0.1.1/dist/ml5.min.js" type="text/javascript"></script> -->
+
   <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 

--- a/javascript/StyleTransfer_Image/index.html
+++ b/javascript/StyleTransfer_Image/index.html
@@ -10,7 +10,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Style Transfer Image Example with Promises</title>
-  <script src="https://unpkg.com/ml5@0.1.1/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
   <style>
   img {

--- a/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/index.html
+++ b/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/index.html
@@ -13,7 +13,7 @@
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+
   <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   <style>
   button {

--- a/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/index.html
+++ b/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/index.html
@@ -13,7 +13,7 @@
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+
   <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
   

--- a/p5js/ImageClassification/ImageClassification_MultipleImages/index.html
+++ b/p5js/ImageClassification/ImageClassification_MultipleImages/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+
   <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 

--- a/p5js/ImageClassification/ImageClassification_Video/index.html
+++ b/p5js/ImageClassification/ImageClassification_Video/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+
   <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 

--- a/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
+++ b/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <!-- <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script> -->
+
   <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   <script src="lib/p5.speech.js"></script>
   

--- a/p5js/ImageClassification/ImageClassification_VideoSound/index.html
+++ b/p5js/ImageClassification/ImageClassification_VideoSound/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <!-- <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script> -->
+
   <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   <script src="lib/p5.speech.js"></script>
   

--- a/p5js/ImageClassification/ImageClassification_VideoSoundTranslate/index.html
+++ b/p5js/ImageClassification/ImageClassification_VideoSoundTranslate/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="lib/p5.speech.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <!-- <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script> -->
+
   <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 

--- a/p5js/KNNClassification/KNNClassification_PoseNet/index.html
+++ b/p5js/KNNClassification/KNNClassification_PoseNet/index.html
@@ -13,7 +13,7 @@
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.2.1/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
 
   <style>
   button {

--- a/p5js/KNNClassification/KNNClassification_Video/index.html
+++ b/p5js/KNNClassification/KNNClassification_Video/index.html
@@ -13,7 +13,7 @@
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.2.1/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
   <style>
   button {

--- a/p5js/KNNClassification/KNNClassification_VideoSound/index.html
+++ b/p5js/KNNClassification/KNNClassification_VideoSound/index.html
@@ -14,7 +14,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="lib/p5.speech.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.2.1/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
   <style>
   button {

--- a/p5js/KNNClassification/KNNClassification_VideoSquare/index.html
+++ b/p5js/KNNClassification/KNNClassification_VideoSquare/index.html
@@ -13,7 +13,7 @@
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.2.1/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
   <style>
   button {

--- a/p5js/LSTM/LSTM_Interactive/index.html
+++ b/p5js/LSTM/LSTM_Interactive/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
 
   <style>
   #original {

--- a/p5js/LSTM/LSTM_Text/index.html
+++ b/p5js/LSTM/LSTM_Text/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/LSTM/LSTM_Text_Stateful/index.html
+++ b/p5js/LSTM/LSTM_Text_Stateful/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
 
 
   <style> body{padding:0; margin:0;} </style>

--- a/p5js/PitchDetection/PitchDetection/index.html
+++ b/p5js/PitchDetection/PitchDetection/index.html
@@ -16,7 +16,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.sound.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/PitchDetection/PitchDetection_Game/index.html
+++ b/p5js/PitchDetection/PitchDetection_Game/index.html
@@ -8,7 +8,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.sound.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/PitchDetection/PitchDetection_Piano/index.html
+++ b/p5js/PitchDetection/PitchDetection_Piano/index.html
@@ -8,7 +8,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.sound.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/Pix2Pix/Pix2Pix_callback/index.html
+++ b/p5js/Pix2Pix/Pix2Pix_callback/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
 
   <style>
     .border-box {

--- a/p5js/Pix2Pix/Pix2Pix_promise/index.html
+++ b/p5js/Pix2Pix/Pix2Pix_promise/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
 
   <style>
     .border-box {

--- a/p5js/PoseNet/PoseNet_image_single/index.html
+++ b/p5js/PoseNet/PoseNet_image_single/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/PoseNet/PoseNet_part_selection/index.html
+++ b/p5js/PoseNet/PoseNet_part_selection/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+
   <script src="http://localhost:8081/ml5.js"></script>
   
 </head>

--- a/p5js/PoseNet/PoseNet_webcam/index.html
+++ b/p5js/PoseNet/PoseNet_webcam/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/SketchRNN/SketchRNN_basic/index.html
+++ b/p5js/SketchRNN/SketchRNN_basic/index.html
@@ -12,8 +12,7 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-    <!-- <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script> -->
-    <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@0.1.3/dist/ml5.min.js" type="text/javascript"></script>
   </head>
 
   <body>

--- a/p5js/SketchRNN/SketchRNN_basic/sketch.js
+++ b/p5js/SketchRNN/SketchRNN_basic/sketch.js
@@ -17,18 +17,29 @@ let x, y;
 // The current "stroke" of the drawing
 let strokePath;
 
-function preload() {
-  // See a list of all supported models: https://github.com/ml5js/ml5-library/blob/master/src/SketchRNN/models.js
-  model = ml5.sketchRNN('cat');
-}
+// For when SketchRNN is fixed
+// function preload() {
+//   // See a list of all supported models: https://github.com/ml5js/ml5-library/blob/master/src/SketchRNN/models.js
+//   model = ml5.sketchRNN('cat');
+// }
 
 function setup() {
   createCanvas(640, 480);
   background(220);
-  startDrawing();
+
+  // Remove for v0.2.3
+  model = ml5.SketchRNN('cat', modelReady);
+
   // Button to reset drawing
   let button = createButton('clear');
   button.mousePressed(startDrawing);
+  // For when SketchRNN is fixed!
+  // startDrawing();
+}
+
+function modelReady() {
+  console.log('model loaded');
+  startDrawing();
 }
 
 // Reset the drawing

--- a/p5js/SketchRNN/SketchRNN_interactive/index.html
+++ b/p5js/SketchRNN/SketchRNN_interactive/index.html
@@ -12,7 +12,7 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-    <!-- <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script> -->
+
     <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   </head>
 

--- a/p5js/StyleTransfer/StyleTransfer_Image/index.html
+++ b/p5js/StyleTransfer/StyleTransfer_Image/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
   <style>
   img {

--- a/p5js/StyleTransfer/StyleTransfer_Video/index.html
+++ b/p5js/StyleTransfer/StyleTransfer_Video/index.html
@@ -12,7 +12,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
   <style>
     img {

--- a/p5js/Word2Vec/index.html
+++ b/p5js/Word2Vec/index.html
@@ -16,7 +16,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
 
   <style>

--- a/p5js/YOLO/YOLO_single_image/index.html
+++ b/p5js/YOLO/YOLO_single_image/index.html
@@ -9,7 +9,7 @@
 
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-	<!-- <script src="https://unpkg.com/ml5@0.2.1/dist/ml5.min.js" type="text/javascript"></script> -->
+
 	<script src="http://localhost:8080/ml5.js"></script>
 	<script src="sketch.js"></script>
 </head>

--- a/p5js/YOLO/YOLO_webcam/index.html
+++ b/p5js/YOLO/YOLO_webcam/index.html
@@ -14,7 +14,7 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.1.2/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@0.2.2/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 <body>


### PR DESCRIPTION
This removes all commented out script tags with localhost or old version of ml5 and updates all examples to using 0.2.2. I left SketchRNN at 0.1.3, however. 