### PR TITLE
simplify CVAE example

### DIFF
--- a/p5js/CVAE/index.html
+++ b/p5js/CVAE/index.html
@@ -1,22 +1,17 @@
 <html>
-<head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-	<title>CVAE with quick_draw</title>
+    <title>CVAE with quick_draw</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/p5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/addons/p5.dom.min.js"></script>
+    <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
+    <script src="sketch.js"></script>
+  </head>
 
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-
-	<script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
-	<script src="sketch.js"></script>
-</head>
-
-<body>
-	<h1>CVAE - Conditional Variational Autoencoder - trained on Google Quick Draw</h1>
-	<p>Press ⬆ up or ⬇ key to change the generate image type.</p>
-	<p>Move your mouse to generate a new image.</p>
-</body>
-
+  <body>
+    <h1>Conditional Variational Autoencoder (CVAE) - trained on Google Quick Draw</h1>
+  </body>
 </html>

--- a/p5js/CVAE/sketch.js
+++ b/p5js/CVAE/sketch.js
@@ -8,47 +8,34 @@ ml5 Example
 CVAE example using p5.js
 === */
 let cvae;
-let labelElement;
-let generatedImage;
-let labelToDraw = 0; // apple
+let labelP;
+let button;
+
+// Note CVAE not working in preload?
+// function preload() {
+// }
 
 function setup() {
-    createCanvas(400, 400);
-
-    labelName = createP('')
-    //Create a new instance with pretrained model
-    cvae = ml5.CVAE('./model/quick_draw/manifest.json', generateImage)
+  createCanvas(200, 200);
+  // Create a new instance with pretrained model
+  cvae = ml5.CVAE('model/quick_draw/manifest.json', modelReady);
+  labelP = createP('apple');
+  button = createButton('generate');
+  button.mousePressed(generateImage);
 }
 
-// Generate a new image on mouseMoved()
-function mouseMoved() {
-    generateImage()
+function gotImage(error, result) {
+  image(result.image, 0, 0, width, height);
 }
 
-function keyPressed(){
-    if(keyCode === UP_ARROW && labelToDraw < cvae.labels.length - 1){
-        labelToDraw++;
-        generateImage()
-    }
-    if(keyCode === DOWN_ARROW && labelToDraw > 0){
-        labelToDraw--;
-        generateImage()
-    }
+function modelReady() {
+  // All the possible labeles
+  console.log(cvae.labels);
+  cvae.generate('apple', gotImage);
 }
 
 function generateImage() {
-    // label 6: apple
-    cvae.generate(cvae.labels[labelToDraw], (err, res) => {
-        generatedImage = res.image;
-    });
-}
-
-function draw() {
-    background(200)
-    if (generatedImage) {
-        labelName.html(cvae.labels[labelToDraw])
-        image(generatedImage, 0, 0, height, height)
-
-    }
-
+  let label = random(cvae.labels);
+  labelP.html(label);
+  cvae.generate(label, gotImage);
 }


### PR DESCRIPTION
## → Description 📝

This is a pull request that simplifies the CVAE example a bit! Apologies if there is a lot of extra changes due to whitespace formatting. We should probably enforce some standards and do linting at some point with the examples.

The things I'm keeping an eye on for examples is:

* ES5 callbacks
* As little DOM in `index.html` as possible.
* Making use of `preload()` (@WenheLI I don't think CVAE supports preload at the moment, is that something we can add?)

Let me know what you think!


