### PR TITLE
simplify Sentiment example

### DIFF
--- a/p5js/Sentiment/index.html
+++ b/p5js/Sentiment/index.html
@@ -1,30 +1,20 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <title>ml5 - Sentiment</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/p5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/addons/p5.dom.min.js"></script>
+    <script src="http://localhost:8080/ml5.js"></script>
+  </head>
 
-<head>
-  <title>ml5 - Sentiment</title>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
-  <script src="http://localhost:8080/ml5.js"></script>
-</head>
-
-<body>
+  <body>
     <h1>Sentiment Analysis Demo</h1>
-    <h2>Using a pre-trained model from TensorFlow.js Layers trained on short movie review. <br>
-      This model is trained to predict the sentiment of a short movie review (as a score between 0 and 1)
-    </h2>
-    <h3>
-      The model is trained using movie reviews that have been truncated to a maximum of 200 words, only the 20000 most used
-      words in the reviews are used. 
-    </h3>
- 
-  
-    <fieldset id="myForm">
-      <legend>Input text to analyze</legend>
-      <input type="text" style="width: 100%" placeholder="input sentence to analize" id="inputBox"></input>
-    </fieldset>
+    <p>
+      This example uses model trained on movie reviews. This model scores the sentiment of text with
+      a value between 0 ("negative") and 1 ("positive"). The movie reviews were truncated to a
+      maximum of 200 words and only the 20,000 most common words in the reviews are used.
+    </p>
 
-  <script src="sketch.js"></script>
-
-</body>
+    <script src="sketch.js"></script>
+  </body>
 </html>

--- a/p5js/Sentiment/sketch.js
+++ b/p5js/Sentiment/sketch.js
@@ -5,36 +5,33 @@ let inputBox;
 let sentimentResult;
 
 function setup() {
-    // update all html elements
-    statusEl = createP('Loading Model...');
-    // initialize sentiment
-    sentiment = ml5.sentiment('movieReviews', modelReady);
+  noCanvas();
+  // initialize sentiment
+  sentiment = ml5.sentiment('movieReviews', modelReady);
 
-    // setup the html environment
-    submitBtn = createButton('submit').parent('myForm');
-    inputBox = select('#inputBox');
-    sentimentResult = createP('sentiment score:').parent('myForm');
+  // setup the html environment
+  statusEl = createP('Loading Model...');
+  inputBox = createInput('Today is the happiest day and is full of rainbows!');
+  inputBox.attribute('size', '75');
+  submitBtn = createButton('submit');
+  sentimentResult = createP('sentiment score:');
 
-    // predicting the sentiment on mousePressed()
-    submitBtn.mousePressed(getSentiment);
-
+  // predicting the sentiment on mousePressed()
+  submitBtn.mousePressed(getSentiment);
 }
 
-function getSentiment(){
-    // get the values from the input
-    const text = inputBox.value();
-    
-    // make the prediction
-    const prediction = sentiment.predict(text);
+function getSentiment() {
+  // get the values from the input
+  const text = inputBox.value();
 
-    // display sentiment result on html page
-    sentimentResult.html('Sentiment score: ' + prediction.score);
+  // make the prediction
+  const prediction = sentiment.predict(text);
+
+  // display sentiment result on html page
+  sentimentResult.html('Sentiment score: ' + prediction.score);
 }
 
 function modelReady() {
-    // model is ready
-    statusEl.html('model loaded');
+  // model is ready
+  statusEl.html('model loaded');
 }
-
-
-


### PR DESCRIPTION
## → Description 📝

This is a pull request that simplifies the Sentiment example a bit! As with #125 apologies if there are extra changes due to whitespace formatting.  I also rewrote the language on the html page that explains the model a bit.

The things I'm keeping an eye on for examples is:

* ES5 callbacks
* As little DOM in `index.html` as possible.
* Making use of `preload()` (@itayniv I don't think sentiment supports preload at the moment, is that something we can add?)

Let me know what you think!