### PR TITLE
changing example to dropdown

### DIFF
--- a/p5js/CVAE/sketch.js
+++ b/p5js/CVAE/sketch.js
@@ -8,20 +8,20 @@ ml5 Example
 CVAE example using p5.js
 === */
 let cvae;
-let labelP;
 let button;
+let dropdown;
 
-// Note CVAE not working in preload?
 // function preload() {
+//   cvae = ml5.CVAE('model/quick_draw/manifest.json');
 // }
 
 function setup() {
   createCanvas(200, 200);
-  // Create a new instance with pretrained model
   cvae = ml5.CVAE('model/quick_draw/manifest.json', modelReady);
-  labelP = createP('apple');
+  // Create a new instance with pretrained model
   button = createButton('generate');
   button.mousePressed(generateImage);
+  background(0);
 }
 
 function gotImage(error, result) {
@@ -30,12 +30,13 @@ function gotImage(error, result) {
 
 function modelReady() {
   // All the possible labeles
-  console.log(cvae.labels);
-  cvae.generate('apple', gotImage);
+  dropdown = createSelect();
+  for (let label of cvae.labels) {
+    dropdown.option(label);
+  }
 }
 
 function generateImage() {
-  let label = random(cvae.labels);
-  labelP.html(label);
+  let label = dropdown.value();
   cvae.generate(label, gotImage);
 }

--- a/p5js/CVAE/sketch.js
+++ b/p5js/CVAE/sketch.js
@@ -17,8 +17,10 @@ let dropdown;
 
 function setup() {
   createCanvas(200, 200);
-  cvae = ml5.CVAE('model/quick_draw/manifest.json', modelReady);
   // Create a new instance with pretrained model
+  cvae = ml5.CVAE('model/quick_draw/manifest.json', modelReady);
+
+  // Create a generate button
   button = createButton('generate');
   button.mousePressed(generateImage);
   background(0);
@@ -29,7 +31,7 @@ function gotImage(error, result) {
 }
 
 function modelReady() {
-  // All the possible labeles
+  // Create dropdown with all possible labels
   dropdown = createSelect();
   for (let label of cvae.labels) {
     dropdown.option(label);


### PR DESCRIPTION
## → Description 📝

Based on feedback from @joeyklee in #125, I'm adjusting the example to use a dropdown! I still couldn't get `preload()` to work with https://github.com/ml5js/ml5-library/pull/360. @WenheLI can you check? With `preload()` I can move the `createSelect()` to `setup()`.

## → Screenshots 🖼

<img width="794" alt="Screen Shot 2019-04-27 at 9 44 30 AM" src="https://user-images.githubusercontent.com/191758/56852496-1453ca80-68d1-11e9-96f1-48a1464cc156.png">
<img width="797" alt="Screen Shot 2019-04-27 at 9 44 21 AM" src="https://user-images.githubusercontent.com/191758/56852497-14ec6100-68d1-11e9-9632-51d1bb95f112.png">