### PR TITLE
Add examples index on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,46 @@ python -m http.server
 
 If you don't know how to start a server, check [this](https://github.com/processing/p5.js/wiki/Local-server) guide.
 
+## Examples Index
+
+Below is the current `release` examples index:
+
+### javascript
+
+### p5js
+
+* [Word2Vec](/ml5-examples/p5js/Word2Vec)
+* [FeatureExtractor_Image_Classification](/ml5-examples/p5js/FeatureExtractor/FeatureExtractor_Image_Classification)
+* [FeatureExtractor_Image_Regression](/ml5-examples/p5js/FeatureExtractor/FeatureExtractor_Image_Regression)
+* [StyleTransfer_Video](/ml5-examples/p5js/StyleTransfer/StyleTransfer_Video)
+* [StyleTransfer_Image](/ml5-examples/p5js/StyleTransfer/StyleTransfer_Image)
+* [ImageClassification_Video](/ml5-examples/p5js/ImageClassification/ImageClassification_Video)
+* [ImageClassification_VideoScavengerHunt](/ml5-examples/p5js/ImageClassification/ImageClassification_VideoScavengerHunt)
+* [ImageClassification_VideoSoundTranslate](/ml5-examples/p5js/ImageClassification/ImageClassification_VideoSoundTranslate)
+* [ImageClassification_VideoSound](/ml5-examples/p5js/ImageClassification/ImageClassification_VideoSound)
+* [ImageClassification_MultipleImages](/ml5-examples/p5js/ImageClassification/ImageClassification_MultipleImages)
+* [KNNClassification_VideoSound](/ml5-examples/p5js/KNNClassification/KNNClassification_VideoSound)
+* [KNNClassification_Video](/ml5-examples/p5js/KNNClassification/KNNClassification_Video)
+* [KNNClassification_PoseNet](/ml5-examples/p5js/KNNClassification/KNNClassification_PoseNet)
+* [KNNClassification_VideoSquare](/ml5-examples/p5js/KNNClassification/KNNClassification_VideoSquare)
+* [SketchRNN_basic](/ml5-examples/p5js/SketchRNN/SketchRNN_basic)
+* [SketchRNN_interactive](/ml5-examples/p5js/SketchRNN/SketchRNN_interactive)
+* [PitchDetection_Game](/ml5-examples/p5js/PitchDetection/PitchDetection_Game)
+* [PitchDetection](/ml5-examples/p5js/PitchDetection/PitchDetection)
+* [CharRNN_Interactive](/ml5-examples/p5js/CharRNN/CharRNN_Interactive)
+* [CharRNN_Text](/ml5-examples/p5js/CharRNN/CharRNN_Text)
+* [CharRNN_Text_Stateful](/ml5-examples/p5js/CharRNN/CharRNN_Text_Stateful)
+* [Pix2Pix_callback](/ml5-examples/p5js/Pix2Pix/Pix2Pix_callback)
+* [Pix2Pix_promise](/ml5-examples/p5js/Pix2Pix/Pix2Pix_promise)
+* [YOLO_webcam](/ml5-examples/p5js/YOLO/YOLO_webcam)
+* [YOLO_single_image](/ml5-examples/p5js/YOLO/YOLO_single_image)
+* [images](/ml5-examples/p5js/YOLO/YOLO_single_image/images)
+* [PoseNet_image_single](/ml5-examples/p5js/PoseNet/PoseNet_image_single)
+* [data](/ml5-examples/p5js/PoseNet/PoseNet_image_single/data)
+* [PoseNet_webcam](/ml5-examples/p5js/PoseNet/PoseNet_webcam)
+* [PoseNet_part_selection](/ml5-examples/p5js/PoseNet/PoseNet_part_selection)
+
+
 ## p5.js web editor examples
 
 The p5.js examples can also be run using the [p5.js web editor](https://alpha.editor.p5js.org). We are [in the process of porting](https://github.com/ml5js/ml5-examples/issues/6) and would welcome any contributions!

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Below is the current `release` examples index:
 
 ### javascript
 
+ml5.js does not require p5.js, however as ml5.js and p5.js have been designed to play nicely with eachother, most of our examples currently are developed together with p5.js. The following "vanilla" javascript examples showcase the use of ml5 without p5.js.
+
+* [FeatureExtractor_Image_Classification](/ml5-examples/javascript/FeatureExtractor_Image_Classification)
+* [ImageClassification_Video](/ml5-examples/javascript/ImageClassification_Video)
+* [ImageClassification](/ml5-examples/javascript/ImageClassification)
+* [StyleTransfer_Image](/ml5-examples/javascript/StyleTransfer_Image)
+* [PoseNet](/ml5-examples/javascript/PoseNet)
+
 ### p5js
 
 * [Word2Vec](/ml5-examples/p5js/Word2Vec)


### PR DESCRIPTION
<!-- MANY MANY THANKS FOR YOUR CONTRIBUTION. ML5 ❤️S YOU! -->
## → Submit changes to the relevant branch 🌲

We have 2 branches you can submit to, **development** or **release**. You'd make us so happy 😊 if you submitted your pull request to the branch that is most relevant for your submission.

- `release` branch


## → Description 📝

- adding an update 🛠

This update adds an index for all the ml5 examples separated by `javascript` and `p5js`. This will allow us to:
1. link to a gh-pages of the examples on our ml5-website-2
2. add iframes on our ml5-website-2 for selected examples of interest
3. while we're working through the kinks of ml5.js projects on the p5 web editor (serving images and other data files can be an issue), we can link directly to this gh-page. 
