### PR TITLE
adding boilerplate ml5 example to be referenced from Getting Started …

### DIFF
--- a/p5js/BoilerPlate-ml5/index.html
+++ b/p5js/BoilerPlate-ml5/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/p5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/addons/p5.dom.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/addons/p5.sound.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <meta charset="utf-8" />
+
+    <script src="https://unpkg.com/ml5@0.3.0/dist/ml5.min.js"></script>
+  </head>
+  <body>
+    <script src="sketch.js"></script>
+  </body>
+</html>

--- a/p5js/BoilerPlate-ml5/sketch.js
+++ b/p5js/BoilerPlate-ml5/sketch.js
@@ -1,0 +1,9 @@
+console.log('ml5 version:', ml5.version);
+
+function setup() {
+  createCanvas(400, 400);
+}
+
+function draw() {
+  background(220);
+}


### PR DESCRIPTION
## → Description 📝

Since the Getting Started page references a "boilerplate" example (with a link to the web editor) I thought maybe it might be good to include it here so that it goes to the ml5 web editor account? (Currently the link is to: https://editor.p5js.org/joeyklee/sketches/5VbXAWaV6)

## → Screenshots 🖼

<img width="846" alt="Screen Shot 2019-05-23 at 1 24 00 PM" src="https://user-images.githubusercontent.com/191758/58273192-2a349e00-7d5e-11e9-9bcb-f3f53a1b6714.png">