### PR TITLE
Adding 2 DoodleNet examples

### DIFF
--- a/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas/index.html
+++ b/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <title>Canvas Image Classification using DoodleNet and p5.js</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/addons/p5.dom.min.js"></script>
 
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
   <style>

--- a/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas/index.html
+++ b/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas/index.html
@@ -1,0 +1,23 @@
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>Canvas Image Classification using DoodleNet and p5.js</title>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
+
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
+  <style>
+    body {
+      background: lightgray;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Canvas Image Classification using DoodleNet and p5.js</h1>
+  <script src="sketch.js"></script>
+</body>
+
+</html>

--- a/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas/sketch.js
+++ b/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas/sketch.js
@@ -32,9 +32,16 @@ function setup() {
   // Whenever mouseReleased event happens on canvas, call "classifyCanvas" function
   canvas.mouseReleased(classifyCanvas);
   // Create a clear canvas button
-  createClearBtn();
-  // Create a div to hold results
-  createResDiv();
+  let button = createButton('Clear Canvas');
+  button.position(7, 44);
+  button.mousePressed(clearCanvas);
+  // Create 'label' and 'confidence' div to hold results
+  label = createDiv('Label: ...');
+  confidence = createDiv('Confidence: ...');
+}
+
+function clearCanvas() {
+  background(255);
 }
 
 function draw() {
@@ -60,25 +67,7 @@ function gotResult(error, results) {
   }
   // The results are in an array ordered by confidence.
   console.log(results);
-  // Get all top 10 labels
-  const labels = results.map(r => r.label);
-  // Get all top 10 confidences, round to 0.01
-  const confidences = results.map(r => nf(r.confidence, 0, 2));
-  label.html('Label: ' + labels);
-  confidence.html('Confidence: ' + confidences);
-}
-
-function createClearBtn() {
-  let button = createButton('Clear Canvas');
-  button.position(7, 44);
-  button.mousePressed(clearCanvas);
-}
-
-function clearCanvas() {
-  background(255);
-}
-
-function createResDiv() {
-  label = createDiv('Label: ...');
-  confidence = createDiv('Confidence: ...');
+  // Show the first label and confidence
+  label.html('Label: ' + results[0].label);
+  confidence.html('Confidence: ' + nf(results[0].confidence, 0, 2)); // Round the confidence to 0.01
 }

--- a/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas/sketch.js
+++ b/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas/sketch.js
@@ -1,0 +1,80 @@
+// Copyright (c) 2018 ml5
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/* ===
+ml5 Example
+Canvas Image Classification using DoodleNet and p5.js
+This example uses a callback pattern to create the classifier
+=== */
+
+// Initialize the Image Classifier method with DoodleNet.
+let classifier;
+
+// A variable to hold the canvas image we want to classify
+let canvas;
+
+// Two variable to hold the label and confidence of the result
+let label;
+let confidence;
+
+function preload() {
+  // Load the DoodleNet Image Classification model
+  classifier = ml5.imageClassifier('DoodleNet');
+}
+
+function setup() {
+  // Create a canvas with 280 x 280 px
+  canvas = createCanvas(280, 280);
+  // Set canvas background to white
+  background(255);
+  // Whenever mouseReleased event happens on canvas, call "classifyCanvas" function
+  canvas.mouseReleased(classifyCanvas);
+  // Create a clear canvas button
+  createClearBtn();
+  // Create a div to hold results
+  createResDiv();
+}
+
+function draw() {
+  // Set stroke weight to 10
+  strokeWeight(15);
+  // Set stroke color to black
+  stroke(0);
+  // If mouse is pressed, draw line between previous and current mouse positions
+  if (mouseIsPressed) {
+    line(pmouseX, pmouseY, mouseX, mouseY);
+  }
+}
+
+function classifyCanvas() {
+  classifier.classify(canvas, gotResult);
+}
+
+// A function to run when we get any errors and the results
+function gotResult(error, results) {
+  // Display error in the console
+  if (error) {
+    console.error(error);
+  }
+  // The results are in an array ordered by confidence.
+  console.log(results);
+  label.html('Label: ' + results[0].label);
+  confidence.html('Confidence: ' + nf(results[0].confidence, 0, 2));
+}
+
+function createClearBtn() {
+  let button = createButton('Clear Canvas');
+  button.position(204, 356);
+  button.mousePressed(clearCanvas);
+}
+
+function clearCanvas() {
+  background(255);
+}
+
+function createResDiv() {
+  label = createDiv('Label: ...');
+  confidence = createDiv('Confidence: ...');
+}

--- a/p5js/ImageClassification/ImageClassification_DoodleNet_Video/index.html
+++ b/p5js/ImageClassification/ImageClassification_DoodleNet_Video/index.html
@@ -1,0 +1,18 @@
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>Webcam Image Classification using DoodleNet and p5.js</title>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
+
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
+</head>
+
+<body>
+  <h1>Webcam Image Classification using DoodleNet and p5.js</h1>
+  <script src="sketch.js"></script>
+</body>
+
+</html>

--- a/p5js/ImageClassification/ImageClassification_DoodleNet_Video/index.html
+++ b/p5js/ImageClassification/ImageClassification_DoodleNet_Video/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <title>Webcam Image Classification using DoodleNet and p5.js</title>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/p5.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/addons/p5.dom.min.js"></script>
 
   <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
 </head>

--- a/p5js/ImageClassification/ImageClassification_DoodleNet_Video/sketch.js
+++ b/p5js/ImageClassification/ImageClassification_DoodleNet_Video/sketch.js
@@ -33,8 +33,10 @@ function preload() {
 }
 
 function setup() {
-  // Create a div to hold results
-  createResDiv();
+  // Create a 'label' and 'confidence' div to hold results
+  label = createDiv('Label: ...');
+  confidence = createDiv('Confidence: ...');
+
   classifyVideo();
 }
 
@@ -51,17 +53,9 @@ function gotResult(error, results) {
   }
   // The results are in an array ordered by confidence.
   console.log(results);
-  // Get all top 10 labels
-  const labels = results.map(r => r.label);
-  // Get all top 10 confidences, round to 0.01
-  const confidences = results.map(r => nf(r.confidence, 0, 2));
-  label.html('Label: ' + labels);
-  confidence.html('Confidence: ' + confidences);
+  // Show the first label and confidence
+  label.html('Label: ' + results[0].label);
+  confidence.html('Confidence: ' + nf(results[0].confidence, 0, 2)); // Round the confidence to 0.01
   // Call classifyVideo again
   classifyVideo();
-}
-
-function createResDiv() {
-  label = createDiv('Label: ...');
-  confidence = createDiv('Confidence: ...');
 }

--- a/p5js/ImageClassification/ImageClassification_DoodleNet_Video/sketch.js
+++ b/p5js/ImageClassification/ImageClassification_DoodleNet_Video/sketch.js
@@ -5,51 +5,42 @@
 
 /* ===
 ml5 Example
-Canvas Image Classification using DoodleNet and p5.js
+Webcam Image Classification using DoodleNet and p5.js
 This example uses a callback pattern to create the classifier
 === */
 
 // Initialize the Image Classifier method with DoodleNet.
 let classifier;
 
-// A variable to hold the canvas image we want to classify
-let canvas;
+// A variable to hold the Webcam video we want to classify
+let video;
 
 // Two variable to hold the label and confidence of the result
 let label;
 let confidence;
 
 function preload() {
+  // Create a camera input
+  video = createCapture(VIDEO, {
+    video: {
+      width: 280,
+      height: 280,
+      aspectRatio: 1
+    } 
+  });
   // Load the DoodleNet Image Classification model
-  classifier = ml5.imageClassifier('DoodleNet');
+  classifier = ml5.imageClassifier('DoodleNet', video);
 }
 
 function setup() {
-  // Create a canvas with 280 x 280 px
-  canvas = createCanvas(280, 280);
-  // Set canvas background to white
-  background(255);
-  // Whenever mouseReleased event happens on canvas, call "classifyCanvas" function
-  canvas.mouseReleased(classifyCanvas);
-  // Create a clear canvas button
-  createClearBtn();
   // Create a div to hold results
   createResDiv();
+  classifyVideo();
 }
 
-function draw() {
-  // Set stroke weight to 10
-  strokeWeight(15);
-  // Set stroke color to black
-  stroke(0);
-  // If mouse is pressed, draw line between previous and current mouse positions
-  if (mouseIsPressed) {
-    line(pmouseX, pmouseY, mouseX, mouseY);
-  }
-}
-
-function classifyCanvas() {
-  classifier.classify(canvas, gotResult);
+// Get a prediction for the current video frame
+function classifyVideo() {
+  classifier.classify(video, gotResult);
 }
 
 // A function to run when we get any errors and the results
@@ -66,16 +57,8 @@ function gotResult(error, results) {
   const confidences = results.map(r => nf(r.confidence, 0, 2));
   label.html('Label: ' + labels);
   confidence.html('Confidence: ' + confidences);
-}
-
-function createClearBtn() {
-  let button = createButton('Clear Canvas');
-  button.position(7, 44);
-  button.mousePressed(clearCanvas);
-}
-
-function clearCanvas() {
-  background(255);
+  // Call classifyVideo again
+  classifyVideo();
 }
 
 function createResDiv() {

--- a/p5js/ImageClassification/ImageClassification_DoodleNet_Video/sketch.js
+++ b/p5js/ImageClassification/ImageClassification_DoodleNet_Video/sketch.js
@@ -40,7 +40,7 @@ function setup() {
 
 // Get a prediction for the current video frame
 function classifyVideo() {
-  classifier.classify(video, gotResult);
+  classifier.classify(gotResult);
 }
 
 // A function to run when we get any errors and the results


### PR DESCRIPTION
## → Submit changes to the relevant branch 🌲
`development`

## → Description 📝
- submitting a new feature 🆕 

## → Screenshots 🖼
<img width="400" alt="Screen Shot 2019-05-25 at 9 47 09 PM" src="https://user-images.githubusercontent.com/8662372/58383007-5ee36800-7f9f-11e9-84a9-dfe1ae61838b.png">
<img width="400" alt="Screen Shot 2019-05-25 at 9 51 49 PM" src="https://user-images.githubusercontent.com/8662372/58383008-5ee36800-7f9f-11e9-87f3-5f45bd51364e.png">


## → Relevant documentation 🌴
This PR adds two `ml5.imageclassifier('DoodleNet')` examples - 
- DoodleNet with canvas
- DoodleNet with webcam video(The doodle needs to be held closely to the webcam with good lighting to have a good result :))



