### PR TITLE
Renaming to ml5.soundClassifier('SpeechCommands18w')

### DIFF
--- a/p5js/SoundClassification/SoundClassification_speechcommand/index.html
+++ b/p5js/SoundClassification/SoundClassification_speechcommand/index.html
@@ -2,7 +2,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Sound classification using speech-commands and p5.js</title>
+  <title>Sound classification using SpeechCommands18w and p5.js</title>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/addons/p5.dom.min.js"></script>
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-  <h1>Sound classification using speech-commands and p5.js</h1>
+  <h1>Sound classification using SpeechCommands18w and p5.js</h1>
   <p>Try to speak the following commands to your microphone: 'zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'up', 'down', 'left', 'right', 'go', 'stop', 'yes', and 'no', in addition to 'background_noise' and 'unknown'</p>
   <script src="sketch.js"></script>
 </body>

--- a/p5js/SoundClassification/SoundClassification_speechcommand/sketch.js
+++ b/p5js/SoundClassification/SoundClassification_speechcommand/sketch.js
@@ -5,21 +5,21 @@
 
 /* ===
 ml5 Example
-Sound classification using speech-commands and p5.js
+Sound classification using SpeechCommands18w and p5.js
 This example uses a callback pattern to create the classifier
 === */
 
-// Initialize a sound classifier method with speech-commands model. A callback needs to be passed.
+// Initialize a sound classifier method with SpeechCommands18w model. A callback needs to be passed.
 let classifier;
-// Options for the speech-commands model, the default probabilityThreshold is 0
+// Options for the SpeechCommands18w model, the default probabilityThreshold is 0
 const options = { probabilityThreshold: 0.7 };
 // Two variable to hold the label and confidence of the result
 let label;
 let confidence;
 
 function preload() {
-  // Load speech-commands sound classifier model
-  classifier = ml5.soundClassifier('speech-commands', options);
+  // Load SpeechCommands18w sound classifier model
+  classifier = ml5.soundClassifier('SpeechCommands18w', options);
 }
 
 function setup() {


### PR DESCRIPTION
## → Submit changes to the relevant branch 🌲
`development`

## → Description 📝
- adding an update 🛠

## → Relevant documentation 🌴
This PR renames `speech-commands` model to `ml5.soundClassifier('SpeechCommands18w')`


