### PR TITLE
Update NeuralNetwork_multiple-layers example: only the first layer needs inputShape

### DIFF
--- a/p5js/NeuralNetwork/NeuralNetwork_multiple-layers/sketch.js
+++ b/p5js/NeuralNetwork/NeuralNetwork_multiple-layers/sketch.js
@@ -10,7 +10,6 @@ const nn_options = {
         }),
         ml5.tf.layers.dense({
             units: 16,
-            inputShape: [1],
             activation: 'sigmoid',
         }),
         ml5.tf.layers.dense({


### PR DESCRIPTION
<!--------------------------------------------
🌈DEAR BELOVED ML5 COMMUNITY MEMBER. WELCOME. 🌈
---------------------------------------------->

Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.


**A good PR 🌟**

### → Step 1:  Which branch are you submitting to? 🌲
Release (for bug fixes)



### → Step 2: Describe your Pull Request 📝
Fixing a Bug
In the NeuralNetwork_multiple-layers example, I think only the first layer needs `inputShape`, the second layer doesn't.




