### PR TITLE
added interactive regression example

### DIFF
--- a/p5js/NeuralNetwork/NeuralNetwork_Interactive_Regression/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_Interactive_Regression/index.html
@@ -1,0 +1,39 @@
+<head>
+  <meta charset="UTF-8">
+  <title>Interactive Regression Example - Neural Network</title>
+
+  <script src="https://cdn.jsdelivr.net/npm/p5@0.10.2/lib/p5.js"></script>
+  <script src="http://localhost:8080/ml5.js" type="text/javascript"></script>
+
+  <style></style>
+</head>
+
+<body>
+  <h1>Interactive Regression Example - Neural Network</h1>
+  <h3>Instructions</h3>
+
+  <ol>
+    <li>Add data by clicking inside the canvas</li>
+    <li>Edit learning rate = amount that the weights are updated during training</li>
+    <li>Edit number of hidden units = number of hidden units in dense layer</li>
+    <li>Edit number of training epochs = number of iterations over entire dataset</li>
+    <li>Edit number of batch size = number of data points to work through before updating the internal model parameters</li>
+    <li>Click on the Train button</li>
+  </ol>
+
+  <form onsubmit="return false;">
+    <label for="neuralNetworkLearningRate">learning rate: </label>
+    <input type="number" name="neuralNetworkLearningRate" id="neuralNetworkLearningRate" value=0.25 step="0.01"><br>
+    <label for="neuralNetworkHiddenUnits">number of hidden units: </label>
+    <input type="number" name="neuralNetworkHiddenUnits" id="neuralNetworkHiddenUnits" value=20><br>
+    <label for="trainEpochs">number train epochs: </label>
+    <input type="number" name="trainEpochs" id="trainEpochs" value=100><br>
+    <label for="trainBatchSize">number batch size: </label>
+    <input type="number" name="trainBatchSize" id="trainBatchSize" value=64><br>
+    <button id="startTraining">Train</button>
+  </form>
+
+  <script src="sketch.js"></script>
+</body>
+
+</html>

--- a/p5js/NeuralNetwork/NeuralNetwork_Interactive_Regression/sketch.js
+++ b/p5js/NeuralNetwork/NeuralNetwork_Interactive_Regression/sketch.js
@@ -1,0 +1,91 @@
+let trainData = [];
+let neuralNetwork;
+
+// selectors for inputs and button
+const inputNeuralNetworkLearningRate = document.getElementById('neuralNetworkLearningRate');
+const inputNeuralNetworkHiddenUnits = document.getElementById('neuralNetworkHiddenUnits');
+const inputTrainEpochs = document.getElementById('trainEpochs');
+const inputTrainBatchSize = document.getElementById('trainBatchSize');
+const buttonStartTrain = document.getElementById('startTraining');
+
+const canvasSize = 800;
+
+// options for NeuralNetwork
+const options = {
+  inputs: 1,
+  outputs: 1,
+  debug: true,
+  task: 'regression',
+  learningRate: 0.25,
+  hiddenUnits: 20,
+}
+
+// training params
+const trainParams = {
+  validationSplit: 0,
+  epochs: 100,
+  batchSize: 64,
+}
+
+buttonStartTrain.addEventListener("click", () => {
+  // get input data
+  options.learningRate = parseFloat(inputNeuralNetworkLearningRate.value);
+  options.hiddenUnits = parseInt(inputNeuralNetworkHiddenUnits.value);
+  trainParams.epochs = parseInt(inputTrainEpochs.value);
+  trainParams.batchSize = parseInt(inputTrainBatchSize.value);
+
+  // and start the training
+  startTraining();
+});
+
+function setup() {
+  createCanvas(canvasSize, canvasSize);
+  background(220);
+}
+
+function mouseClicked() {
+  if (mouseY > 50) {
+    circle(mouseX, mouseY, 10);
+    trainData.push([mouseX, mouseY]);
+  }
+}
+
+function startTraining() {
+  // check if train data
+  if (trainData.length == 0) {
+    alert('Please add some training data by clicking inside the canvas');
+    return;
+  }
+
+  neuralNetwork = ml5.neuralNetwork(options);
+
+  // add training data
+  for (let i = 0; i < trainData.length; i++) {
+    neuralNetwork.addData([trainData[i][0]], [trainData[i][1]]);
+  }
+
+  neuralNetwork.normalizeData();
+  neuralNetwork.train(trainParams, doneTraining);
+}
+
+function doneTraining() {
+  // build x-bases to calculate corresponding y-values. We take every x-value possible of the canvas to make it look like a line
+  xMany = [];
+  for (x = 0; x <= canvasSize; x++) {
+    xMany.push([x]);
+  }
+  
+  // predict corresponding y-values and show as circle
+  neuralNetwork.predictMultiple(xMany, (error, results) => {
+    if (error) {
+      console.log(error); 
+    } else {
+      console.log(results);
+      for (let i = 0; i < results.length; i++){
+        x = xMany[i][0];
+        y = results[i][0]['value'];
+        circle(x, y, 1);
+      }
+    }
+  });
+}


### PR DESCRIPTION
<!--------------------------------------------
🌈DEAR BELOVED ML5 COMMUNITY MEMBER. WELCOME. 🌈
---------------------------------------------->

Dear ml5 community, 

I'm making a Pull Request(PR). Please see the details below.

### → Step 1:  Which branch are you submitting to? 🌲
`development` to add an example for Regression.

### → Step 2: Describe your Pull Request 📝
I am submitting a new interactive example for Regression using the `NeuralNetwork` class.

Previously there were some problems with it, described at https://github.com/ml5js/ml5-library/issues/721. Basically, the issue was that not all data points were taken into account (since the `validationSplit` parameter of the `NeuralNetwork` training option was permanently set to 0.1).

But since this issue is now closed and changes were merged to the `development` branch (see https://github.com/ml5js/ml5-library/commit/f749d4e00b4b87b76902fd4e8a837fd50398e827; `src/NeuralNetwork/NeuralNetwork.js`; `line 108`) the example now works as expected.

The idea behind this example is that one can add multiple data points to use regression to fit a line. The already present example of `NeuralNetwork_Simple_Regression` does not have the feature to add points interactively + to change some core model parameters. This is why I wanted to share this example.

One can add data points and modify:
- `learningRate`
- `hiddenUnits`
- `batchSize`
- `epochs`

and see the changes.

I would not be upset if you decide not to add this example, since it might be a little bit redundant compared to `NeuralNetwork_Simple_Regression`.

### → Step 4: Screenshots or Relevant Documentation 🖼
> Here's some helpful screenshots and/or documentation of the new feature 

![image](https://user-images.githubusercontent.com/42147848/71031852-86a14580-2114-11ea-8770-82cb3de018b3.png)



