### PR TITLE
Part 3: Replace references to ml5 0.4.3 library version with @latest

### DIFF
--- a/d3/KMeans/KMeans_GaussianClusterDemo/index.html
+++ b/d3/KMeans/KMeans_GaussianClusterDemo/index.html
@@ -2,7 +2,7 @@
 	<head>
 	  <title>ml5.js kmeans example</title>
 	  <script src="https://d3js.org/d3.v4.min.js"></script>
-	  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+	  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 	</head>
 	<body>
 		<center>

--- a/javascript/BodyPix/BodyPix_Image/index.html
+++ b/javascript/BodyPix/BodyPix_Image/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>BodyPix with Webcam</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/javascript/BodyPix/BodyPix_Webcam/index.html
+++ b/javascript/BodyPix/BodyPix_Webcam/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>BodyPix with Webcam</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/javascript/BodyPix/BodyPix_Webcam_Parts/index.html
+++ b/javascript/BodyPix/BodyPix_Webcam_Parts/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>BodyPix with Webcam</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/javascript/CVAE/CVAE_QuickDraw/index.html
+++ b/javascript/CVAE/CVAE_QuickDraw/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" >
 
     <title>CVAE with quick_draw</title>
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
     <script src="sketch.js"></script>
   </head>
 

--- a/javascript/CharRNN/CharRNN_Interactive/index.html
+++ b/javascript/CharRNN/CharRNN_Interactive/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Interactive CharRNN Text Generation Example</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/javascript/CharRNN/CharRNN_Text/index.html
+++ b/javascript/CharRNN/CharRNN_Text/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>LSTM Text Generation Example</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/javascript/CharRNN/CharRNN_Text_Stateful/index.html
+++ b/javascript/CharRNN/CharRNN_Text_Stateful/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Stateful CharRNN Text Generation Example</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
 
   <style></style>

--- a/javascript/DCGAN/DCGAN_Random/index.html
+++ b/javascript/DCGAN/DCGAN_Random/index.html
@@ -5,7 +5,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>DCGAN Example</title>
-	<script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+	<script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 	<script src="sketch.js"></script>
 </head>
 

--- a/javascript/FaceApi/FaceApi_Image_Landmarks/index.html
+++ b/javascript/FaceApi/FaceApi_Image_Landmarks/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>FaceApi Landmarks Demo</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/javascript/FaceApi/FaceApi_Video_Landmarks/index.html
+++ b/javascript/FaceApi/FaceApi_Video_Landmarks/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>FaceApi Landmarks Demo</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/javascript/FaceApi/FaceApi_Video_Landmarks_LocalModels/index.html
+++ b/javascript/FaceApi/FaceApi_Video_Landmarks_LocalModels/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>FaceApi Landmarks Demo With Local Models</title>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/javascript/FeatureExtractor/FeatureExtractor_Image_Classification/index.html
+++ b/javascript/FeatureExtractor/FeatureExtractor_Image_Classification/index.html
@@ -5,7 +5,7 @@
   <title>Image Classification using Feature Extraction with MobileNet</title>
 
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/javascript/FeatureExtractor/FeatureExtractor_Image_Regression/index.html
+++ b/javascript/FeatureExtractor/FeatureExtractor_Image_Regression/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Image Regression using Feature Extraction with MobileNet.</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
   
   <style></style>

--- a/javascript/ImageClassification/ImageClassification/index.html
+++ b/javascript/ImageClassification/ImageClassification/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Image Classification Example</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/javascript/ImageClassification/ImageClassification_DoodleNet_Canvas/index.html
+++ b/javascript/ImageClassification/ImageClassification_DoodleNet_Canvas/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Canvas Image Classification using DoodleNet</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   <style></style>
 </head>
 

--- a/javascript/ImageClassification/ImageClassification_DoodleNet_Video/index.html
+++ b/javascript/ImageClassification/ImageClassification_DoodleNet_Video/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Webcam Image Classification using DoodleNet</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/javascript/ImageClassification/ImageClassification_MultipleImages/index.html
+++ b/javascript/ImageClassification/ImageClassification_MultipleImages/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Multiple Image classification using MobileNet</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/javascript/ImageClassification/ImageClassification_Video/index.html
+++ b/javascript/ImageClassification/ImageClassification_Video/index.html
@@ -5,7 +5,7 @@
   <title>Webcam Image Classification using MobileNet</title>
 
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/javascript/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
+++ b/javascript/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Webcam Image Classification with Speech Output using MobileNet</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/javascript/ImageClassification/ImageClassification_VideoSound/index.html
+++ b/javascript/ImageClassification/ImageClassification_VideoSound/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Webcam Image Classification with Speech Output using MobileNet</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/javascript/ImageClassification/ImageClassification_Video_Load/index.html
+++ b/javascript/ImageClassification/ImageClassification_Video_Load/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Webcam Image Classification using a pre-trianed customized model</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/javascript/KNNClassification/KNNClassification_PoseNet/index.html
+++ b/javascript/KNNClassification/KNNClassification_PoseNet/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>PoseNet with KNN Classification on Webcam Images</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/javascript/KNNClassification/KNNClassification_Video/index.html
+++ b/javascript/KNNClassification/KNNClassification_Video/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>KNN Classification on Webcam Images with mobileNet.</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
   <style></style>
 </head>

--- a/javascript/KNNClassification/KNNClassification_VideoSound/index.html
+++ b/javascript/KNNClassification/KNNClassification_VideoSound/index.html
@@ -5,7 +5,7 @@
   <title>KNN Classification on Webcam Images with Speech Output Using mobileNet.</title>
   
   
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
   <style></style>
 </head>

--- a/javascript/KNNClassification/KNNClassification_VideoSquare/index.html
+++ b/javascript/KNNClassification/KNNClassification_VideoSquare/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>KNN Classification on Webcam Images with mobileNet</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
   <style></style>
 </head>

--- a/javascript/PitchDetection/PitchDetection/index.html
+++ b/javascript/PitchDetection/PitchDetection/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
 
   <title>Pitch Detection</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/javascript/PitchDetection/PitchDetection_Game/index.html
+++ b/javascript/PitchDetection/PitchDetection_Game/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Pitch Tone Game</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/javascript/PitchDetection/PitchDetection_Piano/index.html
+++ b/javascript/PitchDetection/PitchDetection_Piano/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
 
   <title>Pitch Detect Piano</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/javascript/Pix2Pix/Pix2Pix_callback/index.html
+++ b/javascript/Pix2Pix/Pix2Pix_callback/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Pix2Pix Edges2Pikachu Example</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/javascript/Pix2Pix/Pix2Pix_promise/index.html
+++ b/javascript/Pix2Pix/Pix2Pix_promise/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Pix2Pix Edges2Pikachu Example</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/javascript/PoseNet/PoseNet_image_single/index.html
+++ b/javascript/PoseNet/PoseNet_image_single/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>PoseNet example on image with single detection</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/javascript/PoseNet/PoseNet_part_selection/index.html
+++ b/javascript/PoseNet/PoseNet_part_selection/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>PoseNet Part Selection</title>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/javascript/PoseNet/PoseNet_webcam/index.html
+++ b/javascript/PoseNet/PoseNet_webcam/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>PoseNet Example</title>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/javascript/Sentiment/Sentiment_Interactive/index.html
+++ b/javascript/Sentiment/Sentiment_Interactive/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>ml5 - Sentiment</title>
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   </head>
 
   <body>

--- a/javascript/Sentiment/index.html
+++ b/javascript/Sentiment/index.html
@@ -2,7 +2,7 @@
 
 <head>
   <title>ml5 - Sentiment</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.8.0/addons/p5.dom.min.js"></script>

--- a/javascript/SketchRNN/SketchRNN_basic/index.html
+++ b/javascript/SketchRNN/SketchRNN_basic/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="UTF-8" >
     <title>SketchRNN</title>
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   </head>
 
   <body>

--- a/javascript/SketchRNN/SketchRNN_interactive/index.html
+++ b/javascript/SketchRNN/SketchRNN_interactive/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="UTF-8" >
     <title>SketchRNN</title>
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   </head>
 
   <body>

--- a/javascript/SoundClassification/SoundClassification_speechcommand/index.html
+++ b/javascript/SoundClassification/SoundClassification_speechcommand/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Sound classification using SpeechCommands18w</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/javascript/SoundClassification/SoundClassification_speechcommand_load/index.html
+++ b/javascript/SoundClassification/SoundClassification_speechcommand_load/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Sound classification using pre-trained custom model</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/javascript/StyleTransfer/StyleTransfer_Image/index.html
+++ b/javascript/StyleTransfer/StyleTransfer_Image/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Style Transfer Image Example with Promises</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
   <style></style>
 </head>

--- a/javascript/StyleTransfer/StyleTransfer_Video/index.html
+++ b/javascript/StyleTransfer/StyleTransfer_Video/index.html
@@ -2,7 +2,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Style Transfer Mirror Example</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
   <style></style>
 </head>

--- a/javascript/UNET/UNET_webcam/index.html
+++ b/javascript/UNET/UNET_webcam/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="UTF-8" >
     <title>UNET example</title>
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   </head>
 
   <body>

--- a/javascript/Word2Vec/Word2Vec_Interactive/index.html
+++ b/javascript/Word2Vec/Word2Vec_Interactive/index.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Word2Vec example Using a pre-trained model on common English words.</title>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 
   <style></style>

--- a/javascript/YOLO/YOLO_single_image/index.html
+++ b/javascript/YOLO/YOLO_single_image/index.html
@@ -5,7 +5,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>YOLO with image</title>
-	<script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+	<script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 	<script src="sketch.js"></script>
 </head>
 

--- a/javascript/YOLO/YOLO_webcam/index.html
+++ b/javascript/YOLO/YOLO_webcam/index.html
@@ -5,7 +5,7 @@
   <title>Real time Object Detection using YOLO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 <body>

--- a/javascript/ml5_boilerplate/index.html
+++ b/javascript/ml5_boilerplate/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>Getting Started with ml5.js</title>
     
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   </head>
 
   <body>

--- a/p5js/BodyPix/BodyPix_Image/index.html
+++ b/p5js/BodyPix/BodyPix_Image/index.html
@@ -5,7 +5,7 @@
   <title>BodyPix with Webcam</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/BodyPix/BodyPix_Preload/index.html
+++ b/p5js/BodyPix/BodyPix_Preload/index.html
@@ -5,7 +5,7 @@
   <title>BodyPix with Webcam</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/BodyPix/BodyPix_Webcam/index.html
+++ b/p5js/BodyPix/BodyPix_Webcam/index.html
@@ -5,7 +5,7 @@
   <title>BodyPix with Webcam</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/BodyPix/BodyPix_Webcam_Parts/index.html
+++ b/p5js/BodyPix/BodyPix_Webcam_Parts/index.html
@@ -5,7 +5,7 @@
   <title>BodyPix with Webcam</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/BodyPix/BodyPix_p5Instance/index.html
+++ b/p5js/BodyPix/BodyPix_p5Instance/index.html
@@ -5,7 +5,7 @@
   <title>BodyPix with Webcam</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/CVAE/CVAE_QuickDraw/index.html
+++ b/p5js/CVAE/CVAE_QuickDraw/index.html
@@ -7,7 +7,7 @@
     <title>CVAE with quick_draw</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
     <script src="sketch.js"></script>
   </head>
 

--- a/p5js/CharRNN/CharRNN_Interactive/index.html
+++ b/p5js/CharRNN/CharRNN_Interactive/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/CharRNN/CharRNN_Text/index.html
+++ b/p5js/CharRNN/CharRNN_Text/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/CharRNN/CharRNN_Text_Stateful/index.html
+++ b/p5js/CharRNN/CharRNN_Text_Stateful/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
 
   <style></style>

--- a/p5js/DCGAN/DCGAN_LatentVector_RandomWalk/index.html
+++ b/p5js/DCGAN/DCGAN_LatentVector_RandomWalk/index.html
@@ -9,7 +9,7 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-	<script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+	<script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 	<script src="sketch.js"></script>
 </head>
 

--- a/p5js/DCGAN/DCGAN_LatentVector_Slider/index.html
+++ b/p5js/DCGAN/DCGAN_LatentVector_Slider/index.html
@@ -9,7 +9,7 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-	<script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+	<script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 	<script src="sketch.js"></script>
 </head>
 

--- a/p5js/DCGAN/DCGAN_Random/index.html
+++ b/p5js/DCGAN/DCGAN_Random/index.html
@@ -9,7 +9,7 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-	<script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+	<script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 	<script src="sketch.js"></script>
 </head>
 

--- a/p5js/FaceApi/FaceApi_Image_Landmarks/index.html
+++ b/p5js/FaceApi/FaceApi_Image_Landmarks/index.html
@@ -5,7 +5,7 @@
   <title>FaceApi Landmarks Demo</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/FaceApi/FaceApi_Video_Landmarks/index.html
+++ b/p5js/FaceApi/FaceApi_Video_Landmarks/index.html
@@ -5,7 +5,7 @@
   <title>FaceApi Landmarks Demo</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/FaceApi/FaceApi_Video_Landmarks_LocalModels/index.html
+++ b/p5js/FaceApi/FaceApi_Video_Landmarks_LocalModels/index.html
@@ -5,7 +5,7 @@
   <title>FaceApi Landmarks Demo With Local Models</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/index.html
+++ b/p5js/FeatureExtractor/FeatureExtractor_Image_Classification/index.html
@@ -6,7 +6,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
     <style></style>
   </head>
 

--- a/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/index.html
+++ b/p5js/FeatureExtractor/FeatureExtractor_Image_Regression/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
   
   <style></style>

--- a/p5js/ImageClassification/ImageClassification/index.html
+++ b/p5js/ImageClassification/ImageClassification/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas/index.html
+++ b/p5js/ImageClassification/ImageClassification_DoodleNet_Canvas/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   <style></style>
 </head>
 

--- a/p5js/ImageClassification/ImageClassification_DoodleNet_Video/index.html
+++ b/p5js/ImageClassification/ImageClassification_DoodleNet_Video/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/ImageClassification/ImageClassification_MultipleImages/index.html
+++ b/p5js/ImageClassification/ImageClassification_MultipleImages/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/ImageClassification/ImageClassification_Video/index.html
+++ b/p5js/ImageClassification/ImageClassification_Video/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
+++ b/p5js/ImageClassification/ImageClassification_VideoScavengerHunt/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   <script src="lib/p5.speech.js"></script>
   
 </head>

--- a/p5js/ImageClassification/ImageClassification_VideoSound/index.html
+++ b/p5js/ImageClassification/ImageClassification_VideoSound/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   <script src="lib/p5.speech.js"></script>
   
 </head>

--- a/p5js/ImageClassification/ImageClassification_VideoSoundTranslate/index.html
+++ b/p5js/ImageClassification/ImageClassification_VideoSoundTranslate/index.html
@@ -8,7 +8,7 @@
   <script src="lib/p5.speech.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/ImageClassification/ImageClassification_Video_Load/index.html
+++ b/p5js/ImageClassification/ImageClassification_Video_Load/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/KMeans/KMeans_imageSegmentation/index.html
+++ b/p5js/KMeans/KMeans_imageSegmentation/index.html
@@ -5,7 +5,7 @@
   <title>Kmeans image segmentation</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/KNNClassification/KNNClassification_PoseNet/index.html
+++ b/p5js/KNNClassification/KNNClassification_PoseNet/index.html
@@ -6,7 +6,7 @@
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/KNNClassification/KNNClassification_Video/index.html
+++ b/p5js/KNNClassification/KNNClassification_Video/index.html
@@ -6,7 +6,7 @@
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
   <style></style>
 </head>

--- a/p5js/KNNClassification/KNNClassification_VideoSound/index.html
+++ b/p5js/KNNClassification/KNNClassification_VideoSound/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="lib/p5.speech.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
   <style></style>
 </head>

--- a/p5js/KNNClassification/KNNClassification_VideoSquare/index.html
+++ b/p5js/KNNClassification/KNNClassification_VideoSquare/index.html
@@ -6,7 +6,7 @@
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
   <style></style>
 </head>

--- a/p5js/NeuralNetwork/NeuralNetwork_Simple_Classification/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_Simple_Classification/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/NeuralNetwork/NeuralNetwork_Simple_Regression/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_Simple_Regression/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/NeuralNetwork/NeuralNetwork_XOR/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_XOR/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/NeuralNetwork/NeuralNetwork_basics/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_basics/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/NeuralNetwork/NeuralNetwork_co2net/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_co2net/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/NeuralNetwork/NeuralNetwork_color_classifier/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_color_classifier/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/NeuralNetwork/NeuralNetwork_load_model/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_load_model/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/NeuralNetwork/NeuralNetwork_load_saved_data/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_load_saved_data/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/NeuralNetwork/NeuralNetwork_lowres_pixels/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_lowres_pixels/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.sound.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/NeuralNetwork/NeuralNetwork_multiple_layers/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_multiple_layers/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.sound.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/NeuralNetwork/NeuralNetwork_musical_face/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_musical_face/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.sound.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/NeuralNetwork/NeuralNetwork_musical_mouse/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_musical_mouse/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.sound.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/NeuralNetwork/NeuralNetwork_pose_classifier/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_pose_classifier/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/NeuralNetwork/NeuralNetwork_titanic/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_titanic/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/NeuralNetwork/NeuralNetwork_xy_classifier/index.html
+++ b/p5js/NeuralNetwork/NeuralNetwork_xy_classifier/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.sound.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/PitchDetection/PitchDetection/index.html
+++ b/p5js/PitchDetection/PitchDetection/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.sound.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/PitchDetection/PitchDetection_Game/index.html
+++ b/p5js/PitchDetection/PitchDetection_Game/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.sound.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/PitchDetection/PitchDetection_Piano/index.html
+++ b/p5js/PitchDetection/PitchDetection_Piano/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.sound.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/Pix2Pix/Pix2Pix_callback/index.html
+++ b/p5js/Pix2Pix/Pix2Pix_callback/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/Pix2Pix/Pix2Pix_promise/index.html
+++ b/p5js/Pix2Pix/Pix2Pix_promise/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 
   <style></style>
 </head>

--- a/p5js/PoseNet/PoseNet_image_single/index.html
+++ b/p5js/PoseNet/PoseNet_image_single/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/PoseNet/PoseNet_part_selection/index.html
+++ b/p5js/PoseNet/PoseNet_part_selection/index.html
@@ -7,7 +7,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/PoseNet/PoseNet_webcam/index.html
+++ b/p5js/PoseNet/PoseNet_webcam/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 

--- a/p5js/Sentiment/Sentiment_Interactive/index.html
+++ b/p5js/Sentiment/Sentiment_Interactive/index.html
@@ -3,7 +3,7 @@
     <title>ml5 - Sentiment</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   </head>
 
   <body>

--- a/p5js/SketchRNN/SketchRNN_basic/index.html
+++ b/p5js/SketchRNN/SketchRNN_basic/index.html
@@ -5,7 +5,7 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   </head>
 
   <body>

--- a/p5js/SketchRNN/SketchRNN_interactive/index.html
+++ b/p5js/SketchRNN/SketchRNN_interactive/index.html
@@ -5,7 +5,7 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   </head>
 
   <body>

--- a/p5js/SoundClassification/SoundClassification_speechcommand/index.html
+++ b/p5js/SoundClassification/SoundClassification_speechcommand/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/SoundClassification/SoundClassification_speechcommand_load/index.html
+++ b/p5js/SoundClassification/SoundClassification_speechcommand_load/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/StyleTransfer/StyleTransfer_Image/index.html
+++ b/p5js/StyleTransfer/StyleTransfer_Image/index.html
@@ -6,7 +6,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
   <style></style>
 </head>

--- a/p5js/StyleTransfer/StyleTransfer_Video/index.html
+++ b/p5js/StyleTransfer/StyleTransfer_Video/index.html
@@ -5,7 +5,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
   <style></style>
 </head>

--- a/p5js/TeachableMachine/ImageModel_TM/index.html
+++ b/p5js/TeachableMachine/ImageModel_TM/index.html
@@ -5,7 +5,7 @@
   <title>Webcam Image Classification using a pre-trained customized model and p5.js</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/TeachableMachine/SoundModel_TM/index.html
+++ b/p5js/TeachableMachine/SoundModel_TM/index.html
@@ -5,7 +5,7 @@
   <title>Webcam Image Classification using a pre-trained customized model and p5.js</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/p5js/UNET/UNET_webcam/index.html
+++ b/p5js/UNET/UNET_webcam/index.html
@@ -4,7 +4,7 @@
     <title>UNET example with p5.js</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   </head>
 
   <body>

--- a/p5js/Word2Vec/Word2Vec_Interactive/index.html
+++ b/p5js/Word2Vec/Word2Vec_Interactive/index.html
@@ -8,7 +8,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 
   <style></style>

--- a/p5js/YOLO/YOLO_single_image/index.html
+++ b/p5js/YOLO/YOLO_single_image/index.html
@@ -9,7 +9,7 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
 
-	<script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+	<script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
 	<script src="sketch.js"></script>
 </head>
 

--- a/p5js/YOLO/YOLO_webcam/index.html
+++ b/p5js/YOLO/YOLO_webcam/index.html
@@ -7,7 +7,7 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/p5.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
-  <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+  <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   
 </head>
 <body>

--- a/p5js/ml5_boilerplate/index.html
+++ b/p5js/ml5_boilerplate/index.html
@@ -6,7 +6,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.dom.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.9.0/addons/p5.sound.min.js"></script>
     
-    <script src="https://unpkg.com/ml5@0.4.3/dist/ml5.min.js" type="text/javascript"></script>
+    <script src="https://unpkg.com/ml5@latest/dist/ml5.min.js" type="text/javascript"></script>
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ml5-examples",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This is the first part of a 3 step process to switch the examples from using a specific library version numbers:
- 1/3: Update ml5 reference script to use @latest (into development branch)
- 2/3: Merge changes from development to release
- **3/3: Replace references to ml5 0.4.3 library version with @latest**
 
If we keep this repo ([see discussion](https://github.com/ml5js/ml5-library/issues/809)), maybe we can think of a better way to coordinate changes to the release and development branch!

### Context
**Approach:**
- Replace all references to the specific ml5 version on imports in the ml5-examples and ml5-boilerplate library with @latest. Delete scripts for updating version numbers in the files.

**Pros:**
- Simplest approach for handling the ml5-example repo and ml5-boilerplate repo while also allowing them to remain separate. Overall, this is probably the least disruptive change to the current workflow.

**Cons:**
- May cause some confusion about which version of the library is being used
- If you make a sketch that specifies @latest and then come back to it a year or so later, it’s possible that there could have been breaking changes to the library that would break the script.
