### PR TITLE
Redirect to the new examples Netlify site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**NOTE: This repository is archived and its contents have been moved into the core [ml5-library](https://github.com/ml5js/ml5-library) repository. If you have an outstanding issue or pull request on this repository, please open it on [ml5-library](https://github.com/ml5js/ml5-library). Please feel free to read more and follow updates on [issue #809](https://github.com/ml5js/ml5-library/issues/809) and [pull request #831](https://github.com/ml5js/ml5-library/pull/831).**
+**NOTE: This repository is archived and its contents have been moved into the core [ml5-library](https://github.com/ml5js/ml5-library) repository. If you have an outstanding issue or pull request on this repository, please open it on [ml5-library](https://github.com/ml5js/ml5-library). Please feel free to read more and follow updates on [issue #809](https://github.com/ml5js/ml5-library/issues/809) and [pull request #831](https://github.com/ml5js/ml5-library/pull/831). You can view the examples index site at https://examples.ml5js.org.**
 
 ---
 # ml5 Examples
@@ -66,7 +66,7 @@ npm run develop
 
 * [ml5 examples in the p5 web editor](https://editor.p5js.org/ml5/sketches)
   * The best way to interact with our examples are using the [p5 web editor](https://editor.p5js.org/ml5/sketches). This is an interactive coding environment.
-* Run the examples using the [example index](https://ml5js.github.io/ml5-examples/public)
+* Run the examples using the [example index](https://examples.ml5js.org)
   * We have examples written in plain javascript, p5.js, and more.
 
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://examples.ml5js.org</title>
+<meta http-equiv="refresh" content="0; URL=https://examples.ml5js.org">
+<link rel="canonical" href="https://examples.ml5js.org">


### PR DESCRIPTION
This adds a redirect from the old examples site (https://ml5js.github.io/ml5-examples/public/) to the new examples site. Follows this approach: https://gist.github.com/domenic/1f286d415559b56d725bee51a62c24a7

We still have Netlify issue (https://community.netlify.com/t/custom-domain-is-owned-by-another-account/11747) that @wenqili and I are looking into, but in the meantime to get this PR in I've set up a redirect from examples.ml5js.org -> https://ml5-examples.netlify.com/ on Google Domains.

Regardless, once this lands we can archive this repo!